### PR TITLE
feat: Improve functionality with non-chat completions

### DIFF
--- a/default_userdata/configs/default_config.json
+++ b/default_userdata/configs/default_config.json
@@ -7,8 +7,8 @@
 	"selectedDescScript": "standard\\pListMcc.js",
 	"selectedExMsgScript": "standard\\mccAliChat.js",
 	"selectedSelfTalkExMsgScript": "standard\\default.js",
-	"inputSequence": "[INST]",
-    "outputSequence": "[/INST]",
+	"inputSequence": "<|user|>",
+	"outputSequence": "<|assistant|>",
 	"textGenerationApiConnectionConfig": {
 		"connection": {
 			"type": "openrouter",

--- a/default_userdata/scripts/actions/standard/aiAgreedToTruce.js
+++ b/default_userdata/scripts/actions/standard/aiAgreedToTruce.js
@@ -7,7 +7,7 @@ module.exports = {
         {
             name: "years",
             type: "number",
-            desc: "Required argument. Specifies the number of years the truce lasts. Set 3 years as default if not provided."
+            desc: "Required argument. Specifies the number of years the truce lasts. Set 3 years as default if not provided"
         }
     ],
     description: `Execute when {{aiName}} and {{playerName}} agree to a mutual truce for a certain number of years.`,

--- a/default_userdata/scripts/actions/standard/aiConvertsToPlayerReligion.js
+++ b/default_userdata/scripts/actions/standard/aiConvertsToPlayerReligion.js
@@ -10,7 +10,7 @@ module.exports = {
             desc: "required argument. Should be equal to (true) if {{aiName}} converts willingly and to (false) if forcefully"
         }
     ],
-    description: `execute when {{aiName}} converts to {{playerName}} faith either willingly or forcefully against {{aiName}} wish`,
+    description: `Execute when {{aiName}} converts to {{playerName}}'s faith either willingly or forcefully against {{aiName}}'s wish`,
 
 	
     /**
@@ -78,7 +78,7 @@ module.exports = {
  
     },
     chatMessage: (args) =>{
-        return `{{aiName}} converted into your religion`
+        return `{{aiName}} converted to your religion.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/actions/standard/aiEmployedByPlayer.js
+++ b/default_userdata/scripts/actions/standard/aiEmployedByPlayer.js
@@ -4,7 +4,7 @@
 module.exports = {
     signature: "aiEmployedByPlayer",
     args: [],
-    description: `execute when {{aiName}} is not ruler or knight and decided to join {{playerName}}'s court`,
+    description: `Execute when {{aiName}} is not a ruler or knight and decides to join {{playerName}}'s court`,
 
     /**
      * @param {GameData} gameData 
@@ -30,7 +30,7 @@ module.exports = {
         
     },
     chatMessage: (args) =>{
-        return `{{aiName}} joined to your court`
+        return `{{aiName}} joined your court.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/actions/standard/aiInjured.js
+++ b/default_userdata/scripts/actions/standard/aiInjured.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "injuryType",
             type: "string",
-            desc: "Type of injury inflicted on {{aiName}} by {{playerName}}. Possible values: injured if simple injure, remove_eye, blind if it last eye, cut_leg, cut_balls, disfigured"
+            desc: "type of injury inflicted on {{aiName}} by {{playerName}}. Possible values: injured if simple injury, remove_eye, blind if it's the last eye, cut_leg, cut_balls, disfigured"
         }
     ],
-    description: `execute when the {{playerName}} injures the {{aiName}} in various ways, based on the injuryType argument`,
+    description: `Execute when {{playerName}} injures {{aiName}} in various ways, based on the injuryType argument`,
     
     check: (gameData) => {
         // Always return true for now

--- a/default_userdata/scripts/actions/standard/aiPaysGoldToPlayer.js
+++ b/default_userdata/scripts/actions/standard/aiPaysGoldToPlayer.js
@@ -10,7 +10,7 @@ module.exports = {
             desc: "the amount of gold {{aiName}} pays to {{playerName}}, should be always positive"
         }
     ],
-    description: `execute when {{aiName}} pays gold to {{playerName}} either willingly or forcefully against {{aiName}} wish and ONLY WHEN {{aiName}} has enough gold to pay`,
+    description: `Execute when {{aiName}} pays gold to {{playerName}} either willingly or forcefully against {{aiName}}'s wish and ONLY WHEN {{aiName}} has enough gold to pay`,
     
     /**
      * @param {GameData} gameData 
@@ -42,10 +42,10 @@ module.exports = {
     },
     chatMessage: (args) =>{
         if (Number(args[0]) <= Number(args[1])) {
-            return `{{aiName}} paid ${args[0]} gold to you`
+            return `{{aiName}} paid ${args[0]} gold to you.`
         }
         else {
-            return `{{aiName}} doesn't have enough gold to pay`
+            return `{{aiName}} doesn't have enough gold to pay.`
         }
     },
     chatMessageClass: "neutral-action-message"

--- a/default_userdata/scripts/actions/standard/allianceDiplomatic.js
+++ b/default_userdata/scripts/actions/standard/allianceDiplomatic.js
@@ -5,7 +5,7 @@ module.exports = {
     signature: "allianceDiplomatic",
     args: [],
 	
-    description: `execute when {{aiName}} and {{playerName}} agree on an alliance.`,
+    description: `Execute when {{aiName}} and {{playerName}} agree on an alliance.`,
 	
     check: (gameData) => {
         let ai = gameData.getAi();

--- a/default_userdata/scripts/actions/standard/assignAiToCouncilPosition.js
+++ b/default_userdata/scripts/actions/standard/assignAiToCouncilPosition.js
@@ -14,10 +14,10 @@ module.exports = {
         {
             name: "council_position",
             type: "string",
-            desc: "The position to which the {{playerName}} decided to assing {{aiName}} to the council. BE CAREFULL! You must choose ONLY from this variants: marshal, steward, spymaster, chancellor"
+            desc: "the position to which the {{playerName}} decided to assign {{aiName}} to the council. BE CAREFUL! You must choose ONLY from these variants: marshal, steward, spymaster, chancellor"
         } 
     ],
-    description: `Run only if the {{playerName}} announces that the {{aiName}} is now appointed to their council! WARNING! Execute ONLY if {{playerName}} diseide to assign {{aiName}} as marshal, steward, spymaster, chancellor`,
+    description: `Run only if the {{playerName}} announces that the {{aiName}} is now appointed to their council! WARNING! Execute ONLY if {{playerName}} decides to assign {{aiName}} as marshal, steward, spymaster, chancellor`,
 
     /**
      * @param {GameData} gameData 
@@ -118,7 +118,7 @@ module.exports = {
     },    
 
     chatMessage: (args) =>{
-        return `You assign {{aiName}} to council as ${args[0]}`
+        return `You assigned {{aiName}} to the council as ${args[0]}.`
     },
     chatMessageClass: "positive-action-message"
 }

--- a/default_userdata/scripts/actions/standard/assignAiToCourtPosition.js
+++ b/default_userdata/scripts/actions/standard/assignAiToCourtPosition.js
@@ -14,7 +14,7 @@ module.exports = {
         {
             name: "court_position",
             type: "string",
-            desc: "The court position to which the {{playerName}} decided to assign {{aiName}}. BE CAREFULL! You must choose ONLY from these variants: physician, keeper_of_swans, travel_leader, master_of_horse, court_jester, master_of_hunt, high_almoner, cupbearer, seneschal, antiquarian, tutor, royal_architect, court_poet, bodyguard, court_champion, musician, food_taster, lady_in_waiting, garuda, chief_eunuch, court_gardener, chief_qadi, wet_nurse, akolouthos"
+            desc: "the court position to which the {{playerName}} decided to assign {{aiName}}. BE CAREFUL! You must choose ONLY from these variants: physician, keeper_of_swans, travel_leader, master_of_horse, court_jester, master_of_hunt, high_almoner, cupbearer, seneschal, antiquarian, tutor, royal_architect, court_poet, bodyguard, court_champion, musician, food_taster, lady_in_waiting, garuda, chief_eunuch, court_gardener, chief_qadi, wet_nurse, akolouthos"
         } 
     ],
     description: `Execute if {{playerName}} decides to assign {{aiName}} to court position of {{playerName}}'s council.`,
@@ -337,7 +337,7 @@ module.exports = {
     },    
 
     chatMessage: (args) =>{
-        return `You assign {{aiName}} to ${args[0]} position`
+        return `You assigned {{aiName}} to the ${args[0]} position.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/actions/standard/becomeCloseFriends.js
+++ b/default_userdata/scripts/actions/standard/becomeCloseFriends.js
@@ -7,7 +7,7 @@ module.exports = {
         {
             name: "reason",
             type: "string",
-            desc: "the reason (the event) that made them become friends. (in past tense)."
+            desc: "the reason (the event) that made them become friends. (in past tense)"
         }
     ],
     description: "Execute when a strong and close friendship formed between {{playerName}} and {{aiName}}.",

--- a/default_userdata/scripts/actions/standard/becomeLovers.js
+++ b/default_userdata/scripts/actions/standard/becomeLovers.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "reason",
             type: "string",
-            desc: "the reason (the event) that made them become lovers of each other. (write it in past tense)."
+            desc: "the reason (the event) that made them become lovers of each other. (write it in past tense)"
         }
     ],
-    description: "Execute when {{playerName}} and {{aiName}} became have good, great or amazing sex with each other and become lovers.",
+    description: "Execute when {{playerName}} and {{aiName}} have good, great, or amazing sex with each other and become lovers.",
 
     /**
      * @param {GameData} gameData 

--- a/default_userdata/scripts/actions/standard/becomeRivals.js
+++ b/default_userdata/scripts/actions/standard/becomeRivals.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "reason",
             type: "string",
-            desc: "the reason (the event) that made them become rivals with eachother. (write it in past tense)."
+            desc: "the reason (the event) that made them become rivals with each other (write it in past tense)"
         }
     ],
-    description: "Execute when {{playerName}} and {{aiName}} became fierce rivals with eachother.",
+    description: "Execute when {{playerName}} and {{aiName}} became fierce rivals with each other.",
 
     /**
      * @param {GameData} gameData 

--- a/default_userdata/scripts/actions/standard/becomeSoulmates.js
+++ b/default_userdata/scripts/actions/standard/becomeSoulmates.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "reason",
             type: "string",
-            desc: "the reason (the event) that made them become soulmates of eachother. (write it in past tense)."
+            desc: "the reason (the event) that made them become soulmates with each other (write it in past tense)"
         }
     ],
-    description: "Execute when {{playerName}} and {{aiName}} became passionate soulmates with eachother.",
+    description: "Execute when {{playerName}} and {{aiName}} became passionate soulmates with each other.",
 
     /**
      * @param {GameData} gameData 

--- a/default_userdata/scripts/actions/standard/fireAiFromCouncil.js
+++ b/default_userdata/scripts/actions/standard/fireAiFromCouncil.js
@@ -46,7 +46,7 @@ module.exports = {
     },    
 
     chatMessage: (args) =>{
-        return `You fired {{aiName}} from council`
+        return `You fired {{aiName}} from the council.`
     },
     chatMessageClass: "negative-action-message"
 }

--- a/default_userdata/scripts/actions/standard/improveOpinionOfPlayer.js
+++ b/default_userdata/scripts/actions/standard/improveOpinionOfPlayer.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "opinion",
             type: "number",
-            desc: "the number of opinion values the relation improves with. Can be between 1 and 5."
+            desc: "the number of opinion values the relation improves with. Can be between 1 and 5"
         }
     ],
-    description: `Execute when {{playerName}}'s last last single dialogue or action drastically improved {{aiName}}'s opinion of {{playerName}}.`,
+    description: `Execute when {{playerName}}'s last single dialogue or action drastically improved {{aiName}}'s opinion of {{playerName}}.`,
 
     /**
      * @param {GameData} gameData 

--- a/default_userdata/scripts/actions/standard/intercourse.js
+++ b/default_userdata/scripts/actions/standard/intercourse.js
@@ -4,7 +4,7 @@
 module.exports = {
     signature: "intercourse",
     args: [],
-    description: `Execute when {{aiName}} and {{playerName}} had sexual intercourse, only execute after the intercourse is over. The act can be both consensual or rape.`,
+    description: `Execute when {{aiName}} and {{playerName}} had sexual intercourse. Only execute after the intercourse is over. The act can be either consensual or rape.`,
 
     /**
      * @param {GameData} gameData 
@@ -29,7 +29,7 @@ module.exports = {
     `);
     },
     chatMessage: (args) =>{
-        return `you lay with {{aiName}}`
+        return `You lay with {{aiName}}.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/actions/standard/intercourseA.js
+++ b/default_userdata/scripts/actions/standard/intercourseA.js
@@ -4,7 +4,7 @@
 module.exports = {
     signature: "intercourseA",
     args: [],
-    description: `Execute only after {{aiName}} and {{playerName}} had sexual intercourse. The act can be both consensual or rape.`,
+    description: `Execute only after {{aiName}} and {{playerName}} had sexual intercourse. The act can be either consensual or rape.`,
 
     /**
      * @param {GameData} gameData 
@@ -34,7 +34,7 @@ module.exports = {
     })
     },
     chatMessage: (args) =>{
-        return `you lay with {{aiName}}`
+        return `You lay with {{aiName}}.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/actions/standard/lowerOpinionOfPlayer.js
+++ b/default_userdata/scripts/actions/standard/lowerOpinionOfPlayer.js
@@ -7,7 +7,7 @@ module.exports = {
         {
             name: "opinion",
             type: "number",
-            desc: "the number of opinion values the relation decreases with. Can be between 1 and 5."
+            desc: "the number of opinion values the relation decreases with. Can be between 1 and 5"
         }
     ],
     description: `Execute when {{playerName}}'s last single dialogue or action drastically lowered {{aiName}}'s opinion of {{playerName}}.`,

--- a/default_userdata/scripts/actions/standard/newAllianceDiplomatic.js
+++ b/default_userdata/scripts/actions/standard/newAllianceDiplomatic.js
@@ -5,7 +5,7 @@ module.exports = {
     signature: "newAllianceDiplomatic",
     args: [],
 	
-    description: `execute when {{aiName}} and {{playerName}} agree on an alliance.`,
+    description: `Execute when {{aiName}} and {{playerName}} agree on an alliance.`,
 	
 
     check: (gameData) => {

--- a/default_userdata/scripts/actions/standard/playerImprisonsAI.js
+++ b/default_userdata/scripts/actions/standard/playerImprisonsAI.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "prisonType",
             type: "string",
-            desc: `type of prison {{aiName}} is sent to by {{playerName}} (Must explicitly mention type). Possible values: default if not specified, house_arrest, dungeon`,
+            desc: "type of prison {{aiName}} is sent to by {{playerName}} (Must explicitly mention type). Possible values: default if not specified, house_arrest, dungeon",
         }
     ],
-    description: `execute when {{aiName}} gets explicitly imprisoned by {{playerName}}`,
+    description: `Execute when {{aiName}} gets explicitly imprisoned by {{playerName}}.`,
     
     check: (gameData) => {
         let ai = gameData.getAi();

--- a/default_userdata/scripts/actions/standard/playerPaysGoldToAi.js
+++ b/default_userdata/scripts/actions/standard/playerPaysGoldToAi.js
@@ -40,7 +40,7 @@ module.exports = {
         gameData.getPlayer().gold += args[0];
     },
     chatMessage: (args) =>{
-        return `You paid ${args[0]} gold to {{aiName}}`
+        return `You paid ${args[0]} gold to {{aiName}}.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/actions/standard/playerVassalizingAI.js
+++ b/default_userdata/scripts/actions/standard/playerVassalizingAI.js
@@ -7,10 +7,10 @@ module.exports = {
         {
             name: "changePoliticalScore",
             type: "number",
-            desc: "Required argument, range (-10, 10). Specifies {{aiName}} vassalization acceptance by {{playerName}}. Positive values mean that {{aiName}} tends to accept vassalization by {{playerName}}. Negative values mean that {{aiName}} tends to reject vassalization by {{playerName}}."
+            desc: "Required argument, range (-10, 10). Specifies {{aiName}} vassalization acceptance by {{playerName}}. Positive values mean that {{aiName}} tends to accept vassalization by {{playerName}}. Negative values mean that {{aiName}} tends to reject vassalization by {{playerName}}"
         }
     ],
-    description: `Execute when {{aiName}} and {{playerName}} are talking about {{playerName}}'s vassalization of {{aiName}} or it's terms.`,
+    description: `Execute when {{aiName}} and {{playerName}} are talking about {{playerName}}'s vassalization of {{aiName}} or its terms.`,
     
     /**
      * @param {GameData} gameData 

--- a/default_userdata/scripts/actions/standard/undressAi.js
+++ b/default_userdata/scripts/actions/standard/undressAi.js
@@ -4,7 +4,7 @@
 module.exports = {
     signature: "undressAi",
     args: [],
-    description: `Execute when {{aiName}} got undressed either willingly or forcefully against her wish.`,
+    description: `Execute when {{aiName}} got undressed either willingly or forcefully against their wish.`,
 
     /**
      * @param {GameData} gameData 
@@ -29,7 +29,7 @@ module.exports = {
     `);
     },
     chatMessage: (args) =>{
-        return `{{aiName}} got undressed`
+        return `{{aiName}} got undressed.`
     },
     chatMessageClass: "neutral-action-message"
 }

--- a/default_userdata/scripts/prompts/description/standard/pListMcc.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc.js
@@ -277,7 +277,7 @@ module.exports = (gameData) =>{
     
         
     function listRelationsToPlayer(char){
-        if(char.relationsToPlayer === 0){
+        if(char.relationsToPlayer.length === 0){
             return `has no relation to ${player.shortName}`;
         }
         else{

--- a/default_userdata/scripts/prompts/description/standard/pListMcc.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc.js
@@ -135,10 +135,10 @@ module.exports = (gameData) =>{
             output+="lowborn ";
         }
     
-        if(char.SheHe === "she"){
+        if(char.sheHe === "she"){
             output+= "woman";
         }
-        else if(char.SheHe === "he"){
+        else if(char.sheHe === "he"){
             output+= "man";
         }
 

--- a/default_userdata/scripts/prompts/example messages/standard/aliChat.js
+++ b/default_userdata/scripts/prompts/example messages/standard/aliChat.js
@@ -35,14 +35,14 @@ module.exports = (gameData) => {
     //trait 1
     
     if(personalityTraits.length > 0){
-        let output = `*${ai.shortName}'s eyes lit up* My personality, my lord? *${ai.sheHe} takes a short pause thinking* Well, I am ${personalityTraits[0].name}, ${traitMessageMap.get(personalityTraits[0].name)}`;
+        let output = `*${ai.shortName}'s eyes light up* My personality, my lord? *${ai.sheHe} takes a short pause, thinking* Well, I am ${personalityTraits[0].name}, ${traitMessageMap.get(personalityTraits[0].name)}`;
 
         msgs.push({
             role: "user",
             name: player.shortName,
             content: "Personality?"
         });
-    
+
         msgs.push({
             role: "assistant",
             name: ai.shortName,
@@ -52,15 +52,15 @@ module.exports = (gameData) => {
     
 
     //trait 2
-    if(personalityTraits.length > 1){   
-        let output = `Yes, *${ai.sheHe} pauses again thinking about what else to say* I am also ${personalityTraits[1].name}, ${traitMessageMap.get(personalityTraits[1].name)}`;
+    if(personalityTraits.length > 1){
+        let output = `Yes, *${ai.sheHe} pauses again, thinking about what else to say* I am also ${personalityTraits[1].name}, ${traitMessageMap.get(personalityTraits[1].name)}`;
 
         msgs.push({
             role: "user",
             name: player.shortName,
-            content: "Anyting else?"
+            content: "Anything else?"
         });
-    
+
         msgs.push({
             role: "assistant",
             name: ai.shortName,
@@ -70,14 +70,14 @@ module.exports = (gameData) => {
 
     //trait 3
     if(personalityTraits.length > 2){
-        let output = `*No, I am also ${personalityTraits[2].name}, ${traitMessageMap.get(personalityTraits[2].name)}`;
+        let output = `No, I am also ${personalityTraits[2].name}, ${traitMessageMap.get(personalityTraits[2].name)}`;
 
         msgs.push({
             role: "user",
             name: player.shortName,
             content: "Is that all?"
         });
-    
+
         msgs.push({
             role: "assistant",
             name: ai.shortName,
@@ -93,15 +93,15 @@ const traitMessageMap = new Map([
     ["Chaste", "I dislike intimate contact, I avoid the temptations of the flesh."],
     ["Lustful", "Carnal desires burn hot in my core."],
     ["Temperate", "I think it's best to enjoy things in moderation."],
-    ["Gluttonous", "I frown at moderation, I want it ALL!."],
+    ["Gluttonous", "I frown at moderation, I want it ALL!"],
     ["Generous", "Acts of benevolence and charity are no strangers to me."],
-    ["Greedy", "I keeps a tight grip on my purse and I alway look for ways to engorge it."],
+    ["Greedy", "I keep a tight grip on my purse and I always look for ways to engorge it."],
     ["Diligent", "I do not shy away from hard work."],
     ["Lazy", "The easiest road in life is the road most taken by me."],
     ["Wrathful", "I am quick to anger and fury."],
     ["Calm", "I take things in stride, I lead a slow-paced life."],
-    ["Impatient", "I think that most things should happen fast: ideally they should happen NOW!."],
-    ["Patient", "To wait and bide my time is a specialty of me."],
+    ["Impatient", "I think that most things should happen fast: ideally they should happen NOW!"],
+    ["Patient", "To wait and bide my time is my specialty."],
     ["Humble", "I do not ask for much in life."],
     ["Arrogant", "I have no problem with my sense of worth."],
     ["Deceitful", "To lie and deceive is in my nature."],
@@ -125,12 +125,12 @@ const traitMessageMap = new Map([
     ["Fickle", "I change my mind more often than not, making me hard to predict."],
     ["Vengeful", "I am slow to forget a slight or someone who does me wrong."],
     ["Forgiving", "I am quick to move on from most things."],
-    ["Eccentric", "my behavior is seen by others to be erratic and irrational."],
+    ["Eccentric", "My behavior is seen by others to be erratic and irrational."],
     ["Rowdy", "I am always on the move, full of energy and mischief. When I am up to something, it is not uncommon for others to get hurt."],
     ["Charming", "I certainly know how to wrap people around my little finger. I am sweet and amiable, which allows me to get away with almost anything."],
-    ["Curious", "There is rarely a silent moment with me. I Constantly ask questions, I am curious about everything and everyone."],
+    ["Curious", "There is rarely a silent moment with me. I constantly ask questions, I am curious about everything and everyone."],
     ["Pensive", "I am often lost in thought, trying to understand the world around me. I often rely on books and systems to make sense of things."],
-    ["Bossy", "I can often be seen ordering other children around. While I am concerned with getting things done the right way, getting things done MY! way is equally important."],
+    ["Bossy", "I can often be seen ordering other children around. While I am concerned with getting things done the right way, getting things done MY way is equally important."],
     ["Loyal", "I take my relations more seriously than most."],
     ["Disloyal", "Where most people see a relationship, I see an opportunity."],
 ]);

--- a/default_userdata/scripts/prompts/example messages/standard/mccAliChat.js
+++ b/default_userdata/scripts/prompts/example messages/standard/mccAliChat.js
@@ -35,14 +35,14 @@ module.exports = (gameData, id) => {
     //trait 1
     
     if(personalityTraits.length > 0){
-        let output = `*${ai.shortName}'s eyes lit up* My personality, my lord? *${ai.sheHe} takes a short pause thinking* Well, I am ${personalityTraits[0].name}, ${traitMessageMap.get(personalityTraits[0].name)}`;
+        let output = `*${ai.shortName}'s eyes light up* My personality, my lord? *${ai.sheHe} takes a short pause, thinking* Well, I am ${personalityTraits[0].name}, ${traitMessageMap.get(personalityTraits[0].name)}`;
 
         msgs.push({
             role: "user",
             name: player.shortName,
             content: "Personality?"
         });
-    
+
         msgs.push({
             role: "assistant",
             name: ai.shortName,
@@ -52,15 +52,15 @@ module.exports = (gameData, id) => {
     
 
     //trait 2
-    if(personalityTraits.length > 1){   
-        let output = `Yes, *${ai.sheHe} pauses again thinking about what else to say* I am also ${personalityTraits[1].name}, ${traitMessageMap.get(personalityTraits[1].name)}`;
+    if(personalityTraits.length > 1){
+        let output = `Yes, *${ai.sheHe} pauses again, thinking about what else to say* I am also ${personalityTraits[1].name}, ${traitMessageMap.get(personalityTraits[1].name)}`;
 
         msgs.push({
             role: "user",
             name: player.shortName,
-            content: "Anyting else?"
+            content: "Anything else?"
         });
-    
+
         msgs.push({
             role: "assistant",
             name: ai.shortName,
@@ -70,7 +70,7 @@ module.exports = (gameData, id) => {
 
     //trait 3
     if(personalityTraits.length > 2){
-        let output = `*No, I am also ${personalityTraits[2].name}, ${traitMessageMap.get(personalityTraits[2].name)}`;
+        let output = `No, I am also ${personalityTraits[2].name}, ${traitMessageMap.get(personalityTraits[2].name)}`;
 
         msgs.push({
             role: "user",
@@ -93,15 +93,15 @@ const traitMessageMap = new Map([
     ["Chaste", "I dislike intimate contact, I avoid the temptations of the flesh."],
     ["Lustful", "Carnal desires burn hot in my core."],
     ["Temperate", "I think it's best to enjoy things in moderation."],
-    ["Gluttonous", "I frown at moderation, I want it ALL!."],
+    ["Gluttonous", "I frown at moderation, I want it ALL!"],
     ["Generous", "Acts of benevolence and charity are no strangers to me."],
-    ["Greedy", "I keeps a tight grip on my purse and I alway look for ways to engorge it."],
+    ["Greedy", "I keep a tight grip on my purse and I always look for ways to engorge it."],
     ["Diligent", "I do not shy away from hard work."],
     ["Lazy", "The easiest road in life is the road most taken by me."],
     ["Wrathful", "I am quick to anger and fury."],
     ["Calm", "I take things in stride, I lead a slow-paced life."],
-    ["Impatient", "I think that most things should happen fast: ideally they should happen NOW!."],
-    ["Patient", "To wait and bide my time is a specialty of me."],
+    ["Impatient", "I think that most things should happen fast: ideally they should happen NOW!"],
+    ["Patient", "To wait and bide my time is my specialty."],
     ["Humble", "I do not ask for much in life."],
     ["Arrogant", "I have no problem with my sense of worth."],
     ["Deceitful", "To lie and deceive is in my nature."],
@@ -125,12 +125,12 @@ const traitMessageMap = new Map([
     ["Fickle", "I change my mind more often than not, making me hard to predict."],
     ["Vengeful", "I am slow to forget a slight or someone who does me wrong."],
     ["Forgiving", "I am quick to move on from most things."],
-    ["Eccentric", "my behavior is seen by others to be erratic and irrational."],
+    ["Eccentric", "My behavior is seen by others to be erratic and irrational."],
     ["Rowdy", "I am always on the move, full of energy and mischief. When I am up to something, it is not uncommon for others to get hurt."],
     ["Charming", "I certainly know how to wrap people around my little finger. I am sweet and amiable, which allows me to get away with almost anything."],
-    ["Curious", "There is rarely a silent moment with me. I Constantly ask questions, I am curious about everything and everyone."],
+    ["Curious", "There is rarely a silent moment with me. I constantly ask questions, I am curious about everything and everyone."],
     ["Pensive", "I am often lost in thought, trying to understand the world around me. I often rely on books and systems to make sense of things."],
-    ["Bossy", "I can often be seen ordering other children around. While I am concerned with getting things done the right way, getting things done MY! way is equally important."],
+    ["Bossy", "I can often be seen ordering other children around. While I am concerned with getting things done the right way, getting things done MY way is equally important."],
     ["Loyal", "I take my relations more seriously than most."],
     ["Disloyal", "Where most people see a relationship, I see an opportunity."],
 ]);

--- a/forge.config.js
+++ b/forge.config.js
@@ -3,8 +3,9 @@ const path = require('path');
 
 module.exports = {
   packagerConfig: {
-     icon: './build/icons/icon.ico',
+    icon: './build/icons/icon.ico',
     //"asar":true
+    ignore: /^\/\./,
   },
   rebuildConfig: {},
   makers: [

--- a/src/configWindow/components/apiSelector.ts
+++ b/src/configWindow/components/apiSelector.ts
@@ -38,8 +38,8 @@ function defineTemplate(label: string){
             </div>
 
             <div class="input-group">
-            <input type="checkbox" id="openrouter-instruct-mode">
-            <label for="openrouter-instruct-mode">Force Instruct mode</label>
+            <input type="checkbox" id="openrouter-use-chat">
+            <label for="openrouter-use-chat">Use Chat Completions API</label>
             </div>
         </div>
 
@@ -106,7 +106,12 @@ function defineTemplate(label: string){
                 <br>
                 <input type="text" id="custom-model">
             </div>
-    
+
+            <div class="input-group">
+                <input type="checkbox" id="custom-use-chat">
+                <label for="custom-use-chat">Use Chat Completions API</label>
+            </div>
+
         </div>
 
         <hr>
@@ -142,13 +147,14 @@ class ApiSelector extends HTMLElement{
     oobaUrlInput: HTMLSelectElement 
     oobaUrlConnectButton: HTMLInputElement 
 
-    openrouterKeyInput: HTMLSelectElement 
-    openrouterModelInput: HTMLInputElement 
-    openrouterInstructModeCheckbox: HTMLInputElement 
+    openrouterKeyInput: HTMLSelectElement
+    openrouterModelInput: HTMLInputElement
+    openrouterUseChatCheckbox: HTMLInputElement
 
-    customUrlInput: HTMLSelectElement 
-    customKeyInput: HTMLInputElement 
-    customModelInput: HTMLSelectElement 
+    customUrlInput: HTMLSelectElement
+    customKeyInput: HTMLInputElement
+    customModelInput: HTMLSelectElement
+    customUseChatCheckbox: HTMLInputElement 
 
     testConnectionButton: HTMLButtonElement 
     testConnectionSpan: HTMLButtonElement 
@@ -188,11 +194,12 @@ class ApiSelector extends HTMLElement{
 
         this.openrouterKeyInput = this.shadow.querySelector("#openrouter-key")!;
         this.openrouterModelInput = this.shadow.querySelector("#openrouter-model")!;
-        this.openrouterInstructModeCheckbox = this.shadow.querySelector("#openrouter-instruct-mode")!;
+        this.openrouterUseChatCheckbox = this.shadow.querySelector("#openrouter-use-chat")!;
 
         this.customUrlInput = this.shadow.querySelector("#custom-url")!;
         this.customKeyInput = this.shadow.querySelector("#custom-key")!;
         this.customModelInput = this.shadow.querySelector("#custom-model")!;
+        this.customUseChatCheckbox = this.shadow.querySelector("#custom-use-chat")!;
 
         this.testConnectionButton = this.shadow.querySelector("#connection-test-button")!;
         this.testConnectionSpan = this.shadow.querySelector("#connection-test-span")!;
@@ -218,36 +225,30 @@ class ApiSelector extends HTMLElement{
         this.displaySelectedApiBox();
 
         
-        if(apiConfig.type == "openai"){
-            
+        if(apiConfig.type === "openai"){
             this.openaiKeyInput.value = apiConfig.key;
-            
             this.openaiModelSelect.value =  apiConfig.model;
         }
-        
-        else if(apiConfig.type == "ooba"){
-            
+        else if(apiConfig.type === "ooba"){
             this.oobaUrlInput.value = apiConfig.key;
         }
-        
-        else if(apiConfig.type == "openrouter"){
-            
+        else if(apiConfig.type === "openrouter"){
             this.openrouterKeyInput.value = apiConfig.key;
-            
             this.openrouterModelInput.value = apiConfig.model;
-            
         }
-        else if(apiConfig.type == "custom"){
+        else if(apiConfig.type === "custom"){
             this.customUrlInput.value = apiConfig.baseUrl;
             this.customKeyInput.value = apiConfig.key;
             this.customModelInput.value = apiConfig.model;
         }
-        else if(apiConfig.type == "gemini"){
+        else if(apiConfig.type === "gemini"){
             this.geminiKeyInput.value = apiConfig.key;
             this.geminiModelInput.value = apiConfig.model;
         }
-        
-        this.openrouterInstructModeCheckbox.checked = apiConfig.forceInstruct;
+
+        // Default to checked; only uncheck if forceInstruct is true for the current apiConfig type
+        this.customUseChatCheckbox.checked = apiConfig.type !== "custom" || !(apiConfig.forceInstruct ?? false);
+        this.openrouterUseChatCheckbox.checked = apiConfig.type !== "openrouter" || !(apiConfig.forceInstruct ?? false);
 
         this.overwriteContextCheckbox.checked = apiConfig.overwriteContext;
         this.customContextNumber.value = apiConfig.customContext;
@@ -403,7 +404,7 @@ class ApiSelector extends HTMLElement{
             baseUrl: "https://api.openai.com/v1",
             key: this.openaiKeyInput.value,
             model: this.openaiModelSelect.value,
-            forceInstruct: this.openrouterInstructModeCheckbox.checked,
+            forceInstruct: false,
             overwriteContext: this.overwriteContextCheckbox.checked,
             customContext: this.customContextNumber.value
         }
@@ -421,7 +422,7 @@ class ApiSelector extends HTMLElement{
             baseUrl: this.oobaUrlInput.value,
             key: "11111111111111111111",
             model: "string",
-            forceInstruct: this.openrouterInstructModeCheckbox.checked,
+            forceInstruct: true,
             overwriteContext: this.overwriteContextCheckbox.checked,
             customContext: this.customContextNumber.value
         }
@@ -439,7 +440,7 @@ class ApiSelector extends HTMLElement{
             baseUrl: "https://openrouter.ai/api/v1",
             key: this.openrouterKeyInput.value,
             model: this.openrouterModelInput.value,
-            forceInstruct: this.openrouterInstructModeCheckbox.checked,
+            forceInstruct: !this.openrouterUseChatCheckbox.checked,
             overwriteContext: this.overwriteContextCheckbox.checked,
             customContext: this.customContextNumber.value
         }
@@ -454,7 +455,7 @@ class ApiSelector extends HTMLElement{
             baseUrl: this.customUrlInput.value,
             key: this.customKeyInput.value,
             model: this.customModelInput.value,
-            forceInstruct: false,
+            forceInstruct: !this.customUseChatCheckbox.checked,
             overwriteContext: this.overwriteContextCheckbox.checked,
             customContext: this.customContextNumber.value
         }

--- a/src/main/conversation/Conversation.ts
+++ b/src/main/conversation/Conversation.ts
@@ -332,11 +332,22 @@ export class Conversation{
                 console.log("Current summary before resummarization: "+this.currentSummary);
                 if(this.summarizationApiConnection.isChat()){
                     console.log('Using chat API for resummarization.');
-                    this.currentSummary = await this.summarizationApiConnection.complete(buildResummarizeChatPrompt(this, messagesToSummarize), false, {});
+                    this.currentSummary = await this.summarizationApiConnection.complete(
+                        buildResummarizeChatPrompt(this, messagesToSummarize),
+                        false,
+                        {},
+                    );
                 }
                 else{
                     console.log('Using completion API for resummarization.');
-                    this.currentSummary = await this.summarizationApiConnection.complete(convertChatToTextNoNames(buildResummarizeChatPrompt(this, messagesToSummarize), this.config), false, {});
+                    this.currentSummary = await this.summarizationApiConnection.complete(
+                        convertChatToTextNoNames(buildResummarizeChatPrompt(this, messagesToSummarize), this.config),
+                        false,
+                        {
+                            stop: [this.config.inputSequence, this.config.outputSequence],
+                            max_tokens: this.config.maxTokens,
+                        },
+                    );
                 }
                
                 console.log("New current summary after resummarization: "+this.currentSummary);

--- a/src/main/conversation/checkActions.ts
+++ b/src/main/conversation/checkActions.ts
@@ -204,21 +204,19 @@ function buildActionChatPrompt(conv: Conversation, actions: Action[]): Message[]
 
     output.push({
         role: "system",
-        content: `Your task is to select the actions you think happened in the last replies. The actions MUST exist in the provided list. You can select multiple actions, seperate them with commas. If a function takes a value, then put it inside the brackets after the function, a function can take either 0 or 1 values. 'Response format: <rationale>Reasoning.</rationale><actions>actionName1(value), actionName2(value)</actions>'`
+        content: `Your task is to select the actions you think happened in the last replies. The actions MUST exist in the provided list. You can select multiple actions, separate them with commas. If a function takes a value, then put it inside the brackets after the function, a function can take either 0 or 1 values.`
     })
 
     output.push({
         role: "user",
-        content: `Choose the most relevant actions that you think happened in the provided dialogue based on the last messages.
-"Prior dialogue:\n"+ ${convertMessagesToString(conv.messages.slice(conv.messages.length-8, conv.messages.length-2), "", "")}
+        content:
+`Choose the most relevant actions that you think happened in the provided dialogue based on the last messages.
+Prior dialogue:
+${convertMessagesToString(conv.messages.slice(conv.messages.length-8, conv.messages.length-2), "", "")}
 ${conv.description}
-"Given these replies:\n${convertMessagesToString(conv.messages.slice(conv.messages.length-2), "", "")}
+Given these replies:
+${convertMessagesToString(conv.messages.slice(conv.messages.length-2), "", "")}
 ${listOfActions}`
-})
-
-output.push({
-    role: "user",
-    content: "Choose the most relevant actions. Response format: <rationale>Reasoning.</rationale><actions>actionName1(value), actionName2(value)</actions>"
 })
 
     return output;

--- a/src/main/conversation/checkActions.ts
+++ b/src/main/conversation/checkActions.ts
@@ -199,12 +199,12 @@ function buildActionChatPrompt(conv: Conversation, actions: Action[]): Message[]
     }
 
     listOfActions += `\n- noop(): Execute when none of the previous actions are a good fit for the given replies.`
-    listOfActions += `\nExplain why and which actions you would trigger (rationale), then write the most appropriate actions (actions). If you think multiple actions should be triggered, then seperate them with commas (,) inside the <actions> tags.`
+    listOfActions += `\nExplain why and which actions you would trigger (rationale), then write the most appropriate actions (actions). If you think multiple actions should be triggered, then separate them with commas (,) inside the <actions> tags.`
     listOfActions+= `\nResponse format: <rationale>Reasoning.</rationale><actions>actionName1(value), actionName2(value)</actions>`
 
     output.push({
         role: "system",
-        content: `Your task is to select the actions you think happened in the last replies. The actions MUST exist in the provided list. You can select multiple actions, separate them with commas. If a function takes a value, then put it inside the brackets after the function, a function can take either 0 or 1 values.`
+        content: `Your task is to select the actions you think happened in the last replies. The actions MUST exist in the provided list. You can select multiple actions, separate them with commas. If a function takes an argument, then put it inside the parentheses after the function. A function can take either 0 or 1 arguments.`
     })
 
     output.push({

--- a/src/main/conversation/checkActions.ts
+++ b/src/main/conversation/checkActions.ts
@@ -1,6 +1,6 @@
 import { Conversation } from "./Conversation";
 import { Config } from "../../shared/Config";
-import { convertMessagesToString } from "./promptBuilder";
+import {convertChatToTextNoNames, convertMessagesToString} from "./promptBuilder";
 import { Message, Action, ActionResponse } from "../ts/conversation_interfaces";
 import { parseVariables } from "../parseVariables";
 
@@ -30,7 +30,7 @@ export async function checkActions(conv: Conversation): Promise<ActionResponse[]
         response = await conv.actionsApiConnection.complete(prompt, false, {} );
     }
     else{
-        let prompt = convertChatToTextPrompt(buildActionChatPrompt(conv, availableActions), conv.config );
+        let prompt = convertChatToTextNoNames(buildActionChatPrompt(conv, availableActions), conv.config );
         response = await conv.actionsApiConnection.complete(
             prompt,
             false,
@@ -219,18 +219,5 @@ ${convertMessagesToString(conv.messages.slice(conv.messages.length-2), "", "")}
 ${listOfActions}`
 })
 
-    return output;
-}
-
-function convertChatToTextPrompt(messages: Message[], config: Config): string{
-    let output: string = "";
-    for(let msg of messages){
-        if(msg.role === "user"){
-            output+=config.inputSequence+"\n";
-        }
-        output += msg.content+"\n";
-    }
-
-    output+=config.outputSequence+"\n";
     return output;
 }

--- a/src/main/conversation/checkActions.ts
+++ b/src/main/conversation/checkActions.ts
@@ -31,7 +31,14 @@ export async function checkActions(conv: Conversation): Promise<ActionResponse[]
     }
     else{
         let prompt = convertChatToTextPrompt(buildActionChatPrompt(conv, availableActions), conv.config );
-        response = await conv.actionsApiConnection.complete(prompt, false, {stop: [conv.config.inputSequence, conv.config.outputSequence]} );
+        response = await conv.actionsApiConnection.complete(
+            prompt,
+            false,
+            {
+                stop: [conv.config.inputSequence, conv.config.outputSequence],
+                max_tokens: conv.config.maxTokens,
+            },
+        );
     }
 
     console.log(`Raw LLM response for actions: ${response}`);

--- a/src/main/conversation/promptBuilder.ts
+++ b/src/main/conversation/promptBuilder.ts
@@ -15,14 +15,14 @@ export function convertChatToText(chat: Message[], config: Config, aiName: strin
         
         switch(msg.role){
             case "system":
-                    output += msg.content+"\n";
+                output += msg.content+"\n";
                 break;
             case "user":
                 output += `${config.inputSequence}\n${msg.name}: ${msg.content}\n`;
                 break;
-                case "assistant":
-                    output += `${config.outputSequence}\n${msg.name}: ${msg.content}\n`;
-                    break;
+            case "assistant":
+                output += `${config.outputSequence}\n${msg.name}: ${msg.content}\n`;
+                break;
         }
     }
 
@@ -31,16 +31,17 @@ export function convertChatToText(chat: Message[], config: Config, aiName: strin
 }
 
 export function convertChatToTextNoNames(messages: Message[], config: Config): string{
-    let output: string = "";
-    for(let msg of messages){
-        if(msg.role === "user"){
-            output+=config.inputSequence+"\n";
+    let output: string[] = [];
+    for (let msg of messages) {
+        if (msg.role === "user") {
+            output.push(config.inputSequence);
+        } else if (msg.role === "assistant") {
+            output.push(config.outputSequence);
         }
-        output += msg.content+"\n";
+        output.push(msg.content);
     }
-
-    output+=config.outputSequence+"\n";
-    return output;
+    output.push(config.outputSequence, "")
+    return output.join("\n");
 }
 
 export function buildChatPrompt(conv: Conversation, character: Character): Message[]{

--- a/src/main/conversation/promptBuilder.ts
+++ b/src/main/conversation/promptBuilder.ts
@@ -362,7 +362,7 @@ function createSecretString(conv: Conversation): string{
     aiSecrets = aiSecrets.concat(conv.gameData.characters.get(conv.gameData.aiID)!.secrets);
     playerSecrets = playerSecrets.concat(conv.gameData.characters.get(conv.gameData.playerID)!.secrets);
 
-    let output ="SECRETS BELOW SHALL NOT BE REVEALED EASY, IF CHARACTER REVEALS IT, IT MAY BE USED AGAINST HIM AND LEAD HIM TO DEATH OR PRISON\n";
+    let output ="SECRETS BELOW SHALL NOT BE REVEALED EASILY. IF A CHARACTER REVEALS IT, IT MAY BE USED AGAINST THEM AND LEAD THEM TO DEATH OR PRISON.\n";
     if(aiSecrets.length>0){
         output += `${conv.gameData.aiName}'s secrets:`;
     }

--- a/src/main/conversation/summarize.ts
+++ b/src/main/conversation/summarize.ts
@@ -8,12 +8,18 @@ export async function summarize(conv: Conversation): Promise<string>{
     if(conv.summarizationApiConnection.isChat()){
         console.log('Using chat API for summarization.');
         summarization = await conv.summarizationApiConnection.complete(buildSummarizeChatPrompt(conv), false, {
-        })
+        });
     }
     else{
         console.log('Using completion API for summarization.');
-        summarization = await conv.summarizationApiConnection.complete(convertChatToTextNoNames(buildSummarizeChatPrompt(conv), conv.config), false, {
-        })
+        summarization = await conv.summarizationApiConnection.complete(
+            convertChatToTextNoNames(buildSummarizeChatPrompt(conv), conv.config),
+            false,
+            {
+                stop: [conv.config.inputSequence, conv.config.outputSequence],
+                max_tokens: conv.config.maxTokens,
+            },
+        );
     }
     console.log(`Summarization complete. Length: ${summarization.length}`);
     return summarization;

--- a/src/main/userDataCheck.ts
+++ b/src/main/userDataCheck.ts
@@ -170,12 +170,10 @@ export async function checkUserData(){
     try {
         await fs.promises.cp(typedefsSourcePath, typedefsDestPath, {})
     } catch (err) {
-        if (err) {
-            console.error(`Error copying gamedata_typedefs.js: ${err}`);
-            throw err;
-        }
-        console.log(`Copied gamedata_typedefs.js from ${typedefsSourcePath} to ${typedefsDestPath}`);
+        console.error(`Error copying gamedata_typedefs.js: ${err}`);
+        throw err;
     }
+    console.log(`Copied gamedata_typedefs.js from ${typedefsSourcePath} to ${typedefsDestPath}`);
 
     console.log('User data check completed successfully.');
     return true;

--- a/src/shared/apiConnection.ts
+++ b/src/shared/apiConnection.ts
@@ -15,7 +15,7 @@ export interface Connection{
     baseUrl: string;
     key: string;
     model: string;
-    forceInstruct: boolean ;//only used by openrouter
+    forceInstruct: boolean; // Weird: when true, forces text completions API; when false, uses chat completions API
     overwriteContext: boolean;
     customContext: number;
 }
@@ -33,7 +33,7 @@ export class ApiConnection{
     type: string; //openrouter, openai, ooba, custom
     client: any;
     model: string;
-    forceInstruct: boolean ;//only used by openrouter
+    forceInstruct: boolean; // Weird: when true, forces text completions API; when false, uses chat completions API
     parameters: Parameters;
     context: number;
     overwriteWarning: boolean;
@@ -102,15 +102,16 @@ export class ApiConnection{
 
     isChat(): boolean {
         console.debug(`--- API CONNECTION: isChat() check. Type: ${this.type}, forceInstruct: ${this.forceInstruct}`);
-        if(this.type === "openai" || (this.type === "openrouter" && !this.forceInstruct ) || this.type === "custom" || this.type === 'gemini'){
+        if(this.type === "openai" || this.type === "gemini"){
             console.debug("isChat() is returning true");
             return true;
         }
-        else{
-            console.debug("isChat() is returning false");
-            return false;
+        if((this.type === "openrouter" || this.type === "custom") && !this.forceInstruct){
+            console.debug("isChat() is returning true (forceInstruct is false)");
+            return true;
         }
-    
+        console.debug("isChat() is returning false");
+        return false;
     }
 
     async complete(


### PR DESCRIPTION
# Improved non-chat completions & more!

Hiya there! I fixed up some stuff in this repo for a friend and was asked to share it back upstream, so here are some neat changes:

- Non-chat completion APIs now use the `max_tokens` parameter configured in the application settings for actions and summaries
  - Many non-chat completion APIs set the default `max_tokens` to 16 when unspecified, which is far too small
- Fixed up the string formatting for action prompts, since it was broken and was leaking quotes and operator symbols into the input
- Made the action prompt template less redundant
- Improved the conversion of chat prompts to non-chat prompts
  - They now include the `outputSequence` marker before the contents of any messages with the `assistant` role
- Added a toggle for custom connection settings to choose between using a chat completions API or a non-chat completions API
  - Changed the "Force Instruct mode" toggle for OpenRouter to match, so it's now also a "Use Chat Completions API" toggle
- Changed the default `inputSequence` and `outputSequence` from `[INST]` and `[/INST]` to `<|user|>` and `<|assistant|>`, respectively
  - In practice, these variables are being used as role-switch markers in a prompt, so they should indicate the roles being switched to
  - `[INST]` and `[/INST]` would make more sense if these were bracketing only the user messages
  - In practice it seems like `<|assistant|>` may also benefit from being changed to something like `<|assistant|><think></think>`, or from adding `<think></think>` elsewhere in prompts, but I didn't make these the default in this PR
- Copyedited for strings used in prompts, and fixed several typos and consistency issues

<details>
<summary>
Enjoy!
</summary>
<pre>
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣴⣿⣿⣿⣿⣿⣿⠿⠿⠿⠿⠿⢿⣿⣿⣿⣿⢋⡁⢹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣦⡀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⡆⠹⠿⠛⣋⣉⣥⣤⣶⣶⣶⣶⣶⣶⣶⣦⣤⣍⠁⣾⠇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣄
⠀⠀⠀⠀⠀⠀⠀⢀⡄⢸⡇⠀⢶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠰⠿⠀⠀⡈⠛⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⡀
⠀⠀⠀⠀⠀⢀⡴⠋⣀⣈⣃⣠⣿⣿⣿⠿⠟⠛⠋⠉⠉⠉⠉⠉⠉⠙⠛⠿⣷⣶⣶⠖⠛⠂⠀⠹⣿⣿⣿⣿⣿⣿⣿⣿⡟⣿⣿⣿⣄
⠀⠀⠀⢀⣴⡏⠤⠮⣿⣿⣿⡿⠟⠉⠀⢀⣀⣤⣤⣶⣶⣶⣶⣶⣶⣤⣄⣀⠀⠉⠛⠀⣸⣷⣶⣾⣿⣿⣿⣿⡏⢿⣿⣿⣿⡘⣿⣿⣿⣆
⠀⠀⢠⣾⣿⣿⣶⡆⢸⠟⢋⣠⣴⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⢿⣿⣿⣦⣤⣿⣿⣿⣿⣿⣿⣿⣿⣿⠈⣿⣿⣿⣧⢹⣿⣿⣿
⠀⢠⣿⣿⣿⣿⣿⣇⣀⣴⣿⣿⣿⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡀⠸⣿⣿⣿⡆⢿⣿⣿
⢠⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡟⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⢹⣿⣿⣿⠘⣿⣿
⣿⣿⣿⣿⣿⣿⣿⡏⣿⣿⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠈⢿⣿⣿⡹⣿⣿⣿⣿⣿⣿⣿⣿⣷⠀⠸⣿⣿⣿⡇⢻⣿
⣿⣿⣿⣿⡟⢻⣿⣧⢹⣿⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠃⠈⢩⣤⣤⡀⣉⡙⠛⢿⣿⣿⣿⣿⡆⠀⣿⣿⣿⣿⠘⣿
⣿⣿⣿⡿⠀⢸⣿⣿⢸⣿⣿⣿⠇⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣟⣠⣾⣿⠘⡌⢿⣿⣷⡌⢿⣷⣾⣿⣿⣿⣿⣿⠀⣿⣿⣿⣿⡇⢿
⣿⣿⡿⠁⠀⣿⣿⠿⠈⣋⣭⣍⠀⠀⠻⣿⣿⣿⣿⣹⣿⣿⣿⣯⢿⣿⣿⣿⣿⡆⣿⣄⢻⣿⣿⣄⠻⣿⣿⣿⣿⣿⣿⠀⣿⣿⣿⣿⣧⢸
⣿⡿⠁⠀⣸⣿⣥⣶⢸⣿⣿⡇⢸⣇⢸⣿⣿⣿⣿⡇⣿⣿⣿⣿⡸⣿⣿⣿⣿⣇⢻⣾⣦⠙⢿⣿⣆⠈⠻⣿⣯⢿⣿⠆⣿⣿⣿⣿⣿
⡟⠁⡰⢰⣿⣿⣿⡏⢸⣿⡿⢀⣿⣿⡀⢿⣿⣿⣿⣿⢸⣿⣿⣿⣧⣿⣿⣿⣿⣿⢸⣿⣿⣿⣦⣙⢿⣧⡐⣌⠻⢿⣿⠀⣿⣿⣿⣿⣿
⠀⡰⣡⣿⣿⣿⣿⠃⣿⡿⠁⣾⣿⣿⣷⣌⢻⣿⣿⣿⡆⢿⣿⣿⣿⣾⣿⣿⣿⡿⢸⣿⡿⠿⠛⠛⠃⠈⠁⢪⣕⠤⡌⢸⣿⣿⣿⣿⡇
⡔⣱⣿⣿⣿⣿⡟⢰⡿⢁⣜⣿⣿⣿⣿⣿⣷⣍⡻⠿⣿⣎⡻⠿⠿⢿⣿⣛⣭⡶⠋⠁⢀⣀⣤⣤⣤⣴⣶⣾⣿⡇⠃⣸⣿⣿⣿⡿
⣰⣿⣿⣿⣿⡿⠁⠜⢁⡾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣾⣿⣿⣿⣿⣿⣿⠁⣠⣴⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠀⣿⣿⣿⣿⠃
⣿⣿⣿⣿⡿⠁⠀⠀⠕⠈⠛⠛⠛⠛⠛⠛⠿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⢸⣿⣿⣿⡏
⣿⣿⣿⡿⠁⠀⠀⠀⠀⣠⣤⣶⣶⣶⣶⣦⣤⣤⣘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⣿⣿⣿⣿⠁
⣿⣿⣿⠃⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠛⢛⣉⣭⣍⡛⢿⣿⣿⣿⣿⣿⣿⡿⢸⣿⣿⣿⡟
⣿⣿⠇⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠋⠁⠀⠀⣠⣾⣿⣿⣿⣿⣿⡌⣿⣿⣿⣿⣿⣿⡇⣾⣿⣿⣿⡇
⣿⡏⠀⠀⠀⠀⠀⠀⠀⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⢀⣼⣿⣿⣿⣿⣿⣿⣿⠇⣿⣿⣿⣿⣿⣿⢀⣿⣿⣿⣿
⣿⠇⠀⠀⠀⠀⠀⠀⠀⠀⠘⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⡀⠠⣾⣿⣿⣿⣿⣿⣿⡿⣫⣾⣿⣿⣿⣿⡿⠟⢸⣿⣿⣿⡇
⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⠻⢿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣦⣭⣭⣽⣿⣿⣿⣿⣿⣿⠿⠟⣋⣥⣶⡷⢸⣿⣿⣿⡇
⣿⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠛⠛⠛⠛⠛⠛⠛⠛⠛⠛⠛⠉⢩⣿⣥⣶⣾⣿⣿⣿⠟⣴⠸⣿⣿⣿⣇
</pre>
</details>