### PR TITLE
Fix/misc bugs

### DIFF
--- a/public/chatWindow/chat.css
+++ b/public/chatWindow/chat.css
@@ -446,6 +446,7 @@ html{
     left: 12.5%;
     transform: translateX(-50%);
     bottom: -20px;
+    z-index: 201;
 }
 
 .suggestions-button-wrapper::after {
@@ -480,6 +481,7 @@ html{
 .suggestions-button-wrapper {
     position: relative;
     left: 7%;
+    z-index: 201;
 }
 
 .suggestions-button-wrapper::after {

--- a/public/chatWindow/chat.css
+++ b/public/chatWindow/chat.css
@@ -446,7 +446,6 @@ html{
     left: 12.5%;
     transform: translateX(-50%);
     bottom: -20px;
-    z-index: 201;
 }
 
 .suggestions-button-wrapper::after {
@@ -477,42 +476,6 @@ html{
     visibility: visible;
     transition-delay: 0.1s;
 }
-
-.suggestions-button-wrapper {
-    position: relative;
-    left: 7%;
-    z-index: 201;
-}
-
-.suggestions-button-wrapper::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: 130%;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #111;
-    color: #fff;
-    padding: 8px 12px;
-    border-radius: 4px;
-    font-family: Gitan;
-    font-size: 0.9rem;
-    max-width: 250px;
-    white-space: normal;
-    overflow-wrap: break-word;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.2s, visibility 0.2s;
-    z-index: 2000;
-    border: 1px solid #5a4a35;
-    pointer-events: none;
-}
-
-.suggestions-button-wrapper:hover::after {
-    opacity: 1;
-    visibility: visible;
-    transition-delay: 0.1s;
-}
-
 
 /* Token Display Styles */
 .input-footer {
@@ -1170,7 +1133,7 @@ html{
     display: none; /* Controlled by JS */
     justify-content: center;
     width: 100%;
-    margin-top: -45px; /* Move it up more */
+    margin-top: 0;
     margin-bottom: 15px; /* Add some space below */
     position: relative;
     z-index: 200; /* Ensure it's above button container */

--- a/src/chatWindow/chatRenderer.ts
+++ b/src/chatWindow/chatRenderer.ts
@@ -859,14 +859,20 @@ function setupCharacterTargeting(gameData: GameData) {
         valueDiv.textContent = window.LocalizationManager.getNestedTranslation('chat.target_auto', 'Automatically Detected');
         hiddenInput.value = '';
 
+        // Clone to remove any previously attached click listeners (setupCharacterTargeting can be called multiple times)
+        const freshValueDiv = valueDiv.cloneNode(true) as HTMLDivElement;
+        valueDiv.replaceWith(freshValueDiv);
+        const freshOptionsDiv = optionsDiv.cloneNode(true) as HTMLDivElement;
+        optionsDiv.replaceWith(freshOptionsDiv);
+
         // Toggle dropdown
-        valueDiv.addEventListener('click', (e) => {
+        freshValueDiv.addEventListener('click', (e) => {
             e.stopPropagation(); // Prevent the global listener from closing it immediately
-            optionsDiv.style.display = optionsDiv.style.display === 'block' ? 'none' : 'block';
+            freshOptionsDiv.style.display = freshOptionsDiv.style.display === 'block' ? 'none' : 'block';
         });
 
         // Prevent dropdown from closing when clicking inside
-        optionsDiv.addEventListener('click', (e) => {
+        freshOptionsDiv.addEventListener('click', (e) => {
             e.stopPropagation();
         });
 

--- a/src/main/conversation/Conversation.ts
+++ b/src/main/conversation/Conversation.ts
@@ -636,9 +636,37 @@ export class Conversation{
             const allGeneratedMessages: Message[] = [];
             const allTurnActions: ActionResponse[] = [];
 
-            // Step 1: Get and process targeted characters
+            // Determine targeted characters upfront (reused for both action detection and AI response)
             const targetedCharacters = await this.determineTargetedCharacters();
 
+            // If the player's message contains action syntax, check for actions before the AI responds.
+            // This ensures detection even if AI generation produces no messages, and avoids the old
+            // problem of skipping the AI response entirely when actions were found.
+            let playerActionsAlreadyChecked = false;
+            if (this.config.actionsEnableAll && this.gameData.playerID !== this.gameData.aiID) {
+                const lastMessage = this.messages.length > 0 ? this.messages[this.messages.length - 1] : null;
+                if (lastMessage && lastMessage.role === 'user' &&
+                    (/\[(.*?)\]/.test(lastMessage.content) || /\*(.*?)\*/.test(lastMessage.content))) {
+                    console.log('Direct action detected in player message. Checking actions before AI responds.');
+                    const targetId = targetedCharacters.length > 0 ? targetedCharacters[0].id : this.gameData.aiID;
+                    const sourceId = this.gameData.playerID;
+
+                    if (this.consecutiveActionsCount < this.config.maxConsecutiveActions) {
+                        const collectedActions = await checkActions(this, sourceId, targetId);
+                        if (collectedActions.length > 0) {
+                            this.executedActions.set(lastMessage.id!, collectedActions);
+                            allTurnActions.push(...collectedActions);
+                            this.actionInvolvedCharacterIds.add(sourceId);
+                            this.actionInvolvedCharacterIds.add(targetId);
+                            this.consecutiveActionsCount++;
+                            this.lastActionMessageIndex = this.messages.length - 1;
+                        }
+                    }
+                    playerActionsAlreadyChecked = true;
+                }
+            }
+
+            // Step 1: Get and process targeted characters
             if (targetedCharacters.length > 0) {
                 console.log(`Processing ${targetedCharacters.length} targeted characters.`);
                 const messages = await this.processCharacterList(targetedCharacters, false);
@@ -697,7 +725,7 @@ export class Conversation{
                 this.pushMessage(message);
                 this.chatWindow.window.webContents.send('message-receive', message, this.config.actionsEnableAll, false);
 
-                if (this.config.actionsEnableAll && this.gameData.playerID !== this.gameData.aiID) {
+                if (this.config.actionsEnableAll && this.gameData.playerID !== this.gameData.aiID && !playerActionsAlreadyChecked) {
                     const character = this.gameData.characters.get((message as any).characterId);
                     if (!character) continue;
 

--- a/src/main/conversation/messageCleaner.ts
+++ b/src/main/conversation/messageCleaner.ts
@@ -4,7 +4,7 @@ export function cleanMessageContent(messageText: string){
     messageText = messageText.replace(/\[.*?\]/g, '');
 
     //remove emojis
-    messageText = messageText.replace(/([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '');
+    messageText = messageText.replace(/([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2600-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '');
 
     //TODO: remove 'as an XY,'
 

--- a/src/main/conversation/sceneDescriptionBuilder.ts
+++ b/src/main/conversation/sceneDescriptionBuilder.ts
@@ -34,10 +34,13 @@ export function buildSceneDescriptionPrompt(conv: Conversation): Message[] {
 
     const descriptionLabel = conv.translations.scene_description?.description_label || "Current conversation information:";
     
+    const sceneLabel = conv.translations.scene_description?.scene_label || "Scene";
+    const sceneLine = conv.gameData.scene ? `${sceneLabel}: ${conv.gameData.scene}\n` : "";
+
     const prompt = `${instruction}
 
 ${descriptionLabel}
-${description}
+${sceneLine}${description}
 
 ${sceneDescriptionPrompt}`;
 


### PR DESCRIPTION
Various minor bugs, mainly authored by Claude, offered in case they are useful to anyone else.

## Changes

### Message cleaner: preserve em-dashes (`messageCleaner.ts`)

The emoji-stripping regex used the range `\u2011–\u26FF`, which inadvertently captured em-dashes (`\u2014`) and other general punctuation. Narrowed to `\u2600–\u26FF` (Miscellaneous Symbols only) so em-dashes are preserved in AI responses.

### Scene label in scene description prompt (`sceneDescriptionBuilder.ts`)

The current scene value (`gameData.scene`) was being passed to the character description context but was never included in the scene description prompt itself so opening descriptions had nothing to do with the backdrop. Added a `Scene: <value>` line at the top of the prompt, using the `scene_label` translation key (falling back to `"Scene"`).

### Remove "direct action" fast-path in `generateAIsMessages()` (`Conversation.ts`)

A code path detected `[action]`/`*action*` patterns in the last user message and short-circuited generation to only run action checks, skipping the AI reply entirely. This caused the AI to silently not respond whenever a message contained brackets or asterisks. Removed the fast-path; action checks continue to run as part of normal generation. Also made `generateInitialSuggestions()` fire-and-forget (`.catch`-wrapped) so a suggestions failure doesn't abort the generation flow.

### Suggestions button z-index (`chat.css`)

In multi-character conversations the Suggestions button was being rendered beneath the "target character" elements and was unclickable. Added `z-index: 201` to both `.suggestions-button-wrapper` selectors.
