### PR TITLE
Feat/game date and letter rehydration

### DIFF
--- a/src/main/letter/LetterManager.ts
+++ b/src/main/letter/LetterManager.ts
@@ -297,12 +297,15 @@ create_artifact = {
 \twealth = scope:wealth
 \tsave_scope_as = votc_latest_letter
 }
-scope:votc_latest_letter = {
-set_variable = { name = votc_letter_artifact value = yes}
-}
-set_global_variable = {
-\tname = votc_latest_letter
-\tvalue = scope:votc_latest_letter
+if = {
+\tlimit = { exists = scope:votc_latest_letter }
+\tscope:votc_latest_letter = {
+\t\tset_variable = { name = votc_letter_artifact value = yes}
+\t}
+\tset_global_variable = {
+\t\tname = votc_latest_letter
+\t\tvalue = scope:votc_latest_letter
+\t}
 }
 trigger_event = message_event.362`;
     

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -254,10 +254,56 @@ let letterThreadFullNotified = false;
 let currentTotalDays: number = 0;
 const storedLetters: Map<string, StoredLetter> = new Map();
 let lastLetterSentToGame: StoredLetter | null = null;
+let lastLetterSentToGameTime: number = 0;
+const LETTER_DELIVERY_TIMEOUT_MS = 60_000; // 60 seconds — if no VOTC:LETTER_ACCEPTED, assume delivery failed
 
+
+function rehydratePendingLetters(playerId: string): void {
+    const letterManager = LetterManager.getInstance();
+    const allLetters = letterManager.getAllLetters(playerId);
+
+    const pendingReplies = allLetters.filter(l =>
+        !l.isPlayerSender &&
+        l.status === 'pending' &&
+        l.delivered === false &&
+        l.replyToId
+    );
+
+    let rehydratedCount = 0;
+    for (const reply of pendingReplies) {
+        if (storedLetters.has(reply.replyToId!)) continue;
+
+        const original = allLetters.find(l => l.id === reply.replyToId);
+        if (!original) {
+            console.warn(`rehydratePendingLetters: Could not find original letter ${reply.replyToId} for pending reply ${reply.id}`);
+            continue;
+        }
+
+        const expectedDeliveryDay = original.totalDays + original.delay;
+        storedLetters.set(original.id, {
+            letter: reply,
+            originalLetter: original,
+            expectedDeliveryDay
+        });
+        rehydratedCount++;
+        console.log(`rehydratePendingLetters: Re-queued reply for letter ${original.id}, expectedDeliveryDay: ${expectedDeliveryDay}`);
+    }
+
+    if (rehydratedCount > 0) {
+        console.log(`rehydratePendingLetters: Re-hydrated ${rehydratedCount} pending letter replies.`);
+        checkAndDeliverLetters();
+    }
+}
 
 async function checkAndDeliverLetters() {
     const letterManager = LetterManager.getInstance();
+
+    // If a previous delivery never got VOTC:LETTER_ACCEPTED, unblock after the timeout.
+    if (lastLetterSentToGame && Date.now() - lastLetterSentToGameTime > LETTER_DELIVERY_TIMEOUT_MS) {
+        console.warn(`Letter delivery timed out for letter ${lastLetterSentToGame.originalLetter.id} — no VOTC:LETTER_ACCEPTED received. Clearing to allow future deliveries.`);
+        lastLetterSentToGame = null;
+    }
+
     // Use a copy of keys to allow modification during iteration
     const letterIds = Array.from(storedLetters.keys());
     for (const letterId of letterIds) {
@@ -276,6 +322,7 @@ async function checkAndDeliverLetters() {
             // The letter is being sent to the game, but not yet confirmed as delivered.
             letterManager.deliverLetter(storedLetter, config, currentDateString);
             lastLetterSentToGame = storedLetter; // Track the letter sent
+            lastLetterSentToGameTime = Date.now();
             storedLetters.delete(letterId); // Remove from pending queue
 
             // Since the mod probably handles one at a time, break after sending one.
@@ -389,6 +436,12 @@ app.on('ready',  async () => {
     diaryGenerator = new DiaryGenerator(config);
     loadTranslations(config.language);
     console.log('Configuration loaded successfully.');
+
+    // Re-hydrate any pending reply letters that were not delivered before the last app restart.
+    const letterManager = LetterManager.getInstance();
+    for (const { id } of letterManager.getAllPlayerIdsWithLetters()) {
+        rehydratePendingLetters(id);
+    }
 
     autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
         const dialogOpts = {
@@ -775,7 +828,6 @@ clipboardListener.on('VOTC:IN', async () =>{
 
         // Import letters from log
         await conversation.letterManager.importLettersFromLog(config, gameData, String(gameData.playerID), gameData.date, String(gameData.aiID));
-
 
         // Consolidate chat-start and chat-history into a single event to prevent race conditions
         const historicalMetadata = conversation.historicalConversations || [];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -381,6 +381,40 @@ function processLogLine(line: string) {
     }
 }
 
+async function initCurrentDateFromLog(): Promise<void> {
+    const debugLogPath = path.join(config.userFolderPath, 'logs', 'debug.log');
+    if (!config.userFolderPath || !fs.existsSync(debugLogPath)) return;
+
+    const CHUNK_SIZE = 512 * 1024; // 512KB — enough to find a recent VOTC:DATE
+    let handle;
+    try {
+        handle = await fs.promises.open(debugLogPath, 'r');
+        const { size } = await handle.stat();
+        const position = Math.max(0, size - CHUNK_SIZE);
+        const buffer = Buffer.alloc(size - position);
+        await handle.read(buffer, 0, buffer.length, position);
+        const lines = buffer.toString('utf8').split(/\r?\n/);
+
+        const dateRegex = /VOTC:DATE\/;\/(\d+)/;
+        let latestDays = 0;
+        for (const line of lines) {
+            const match = line.match(dateRegex);
+            if (match) {
+                const days = Number(match[1]);
+                if (days > latestDays) latestDays = days;
+            }
+        }
+        if (latestDays > 0) {
+            currentTotalDays = latestDays;
+            console.log(`initCurrentDateFromLog: Initialized currentTotalDays to ${currentTotalDays} from log.`);
+        }
+    } catch (err) {
+        console.warn(`initCurrentDateFromLog: Could not read log: ${err}`);
+    } finally {
+        if (handle) await handle.close();
+    }
+}
+
 let lastSize = 0;
 function startLogTailing() {
     const debugLogPath = path.join(config.userFolderPath, 'logs', 'debug.log');
@@ -436,6 +470,9 @@ app.on('ready',  async () => {
     diaryGenerator = new DiaryGenerator(config);
     loadTranslations(config.language);
     console.log('Configuration loaded successfully.');
+
+    // Initialize the current game date from the last known VOTC:DATE in the log.
+    await initCurrentDateFromLog();
 
     // Re-hydrate any pending reply letters that were not delivered before the last app restart.
     const letterManager = LetterManager.getInstance();
@@ -823,6 +860,9 @@ clipboardListener.on('VOTC:IN', async () =>{
         }
 
         console.log("New conversation started!");
+        if (gameData.totalDays) {
+            updateCurrentDate(gameData.totalDays);
+        }
         conversation = new Conversation(gameData, config, chatWindow, userDataPath);
         await conversation.loadHistory();
 


### PR DESCRIPTION
I was having a lot of trouble with letters never arriving. I think the main reason for this is on the mod side, with the "letter runner" event not pulsing properly (and hence not writing `VOTC:DATE` lines) unless a letter has been written within that game session, and even then it seems to stop sometimes. 

This PR doesn't solve the fundamental problem, but it least means that if a session is ended while letters are pending, they should get delivered next time round.

## Changes

### Initialize current game date on startup (`main.ts`)
Previously `currentTotalDays` started at `0` until the first `VOTC:IN` clipboard event fired. Added `initCurrentDateFromLog()`, called during `app.on('ready')`, which reads the last 512 KB of `debug.log` and scans for `VOTC:DATE` lines to seed `currentTotalDays` from the most recent known game date. This means letter delivery timing is correct immediately on VOTC startup rather than only after the first in-game event.

Also ensures `currentTotalDays` is updated when a new conversation starts (`gameData.totalDays` on the `VOTC:IN` handler).

### Rehydrate pending letter replies on startup (`main.ts`, `LetterManager.ts`)
Pending reply letters (status `pending`, `delivered: false`, with a `replyToId`) were lost on app restart because the in-memory `storedLetters` queue was never repopulated. Added `rehydratePendingLetters(playerId)`, called at startup for every player with stored letters, which finds undelivered replies, reconstructs their `StoredLetter` entries (including `expectedDeliveryDay`), and re-queues them for delivery.

Added a 60-second delivery timeout: if a letter is sent to the game but no `VOTC:LETTER_ACCEPTED` is received within 60 s, `lastLetterSentToGame` is cleared so the queue is no longer blocked.

Also wrapped the `scope:votc_latest_letter` assignment in the generated CK3 script in an `if = { limit = { exists = ... } }` guard to prevent a script error when the scope is unavailable.
