### PR TITLE
Rework character relatives context and break down opinions

### DIFF
--- a/default_userdata/scripts/actions/standard/agreeToTruce.js
+++ b/default_userdata/scripts/actions/standard/agreeToTruce.js
@@ -51,7 +51,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             // Simulate conversation opinion for AI-AI
             if (opinionOfSource > 0) {
                 conversationOpinion = 15;

--- a/default_userdata/scripts/actions/standard/allianceDiplomatic.js
+++ b/default_userdata/scripts/actions/standard/allianceDiplomatic.js
@@ -30,7 +30,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             // Simulate conversation opinion for AI-AI
             conversationOpinion = opinionOfSource > 0 ? opinionOfSource / 2 : 0;
         }

--- a/default_userdata/scripts/actions/standard/becomeBestFriends.js
+++ b/default_userdata/scripts/actions/standard/becomeBestFriends.js
@@ -52,7 +52,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
             // No generic conversation opinion, so we'll have to make do.

--- a/default_userdata/scripts/actions/standard/becomeBloodBrothers.js
+++ b/default_userdata/scripts/actions/standard/becomeBloodBrothers.js
@@ -52,7 +52,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
             // No generic conversation opinion, so we'll have to make do.

--- a/default_userdata/scripts/actions/standard/becomeCloseFriends.js
+++ b/default_userdata/scripts/actions/standard/becomeCloseFriends.js
@@ -52,7 +52,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
             // Simulate conversation opinion for AI-AI

--- a/default_userdata/scripts/actions/standard/becomeLovers.js
+++ b/default_userdata/scripts/actions/standard/becomeLovers.js
@@ -52,7 +52,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
             // Simulate conversation opinion for AI-AI

--- a/default_userdata/scripts/actions/standard/becomeNemesis.js
+++ b/default_userdata/scripts/actions/standard/becomeNemesis.js
@@ -52,7 +52,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
             // Simulate conversation opinion for AI-AI

--- a/default_userdata/scripts/actions/standard/becomeRivals.js
+++ b/default_userdata/scripts/actions/standard/becomeRivals.js
@@ -50,7 +50,7 @@ module.exports = {
             relations = target.relationsToPlayer;
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
         }

--- a/default_userdata/scripts/actions/standard/becomeSoulmates.js
+++ b/default_userdata/scripts/actions/standard/becomeSoulmates.js
@@ -52,7 +52,7 @@ module.exports = {
             conversationOpinion = target.getOpinionModifierValue("From conversations");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             const relationEntry = target.relationsToCharacters.find(r => r.id === source.id);
             relations = relationEntry ? relationEntry.relations : [];
             // Simulate conversation opinion for AI-AI

--- a/default_userdata/scripts/actions/standard/improveOpinion.js
+++ b/default_userdata/scripts/actions/standard/improveOpinion.js
@@ -55,7 +55,7 @@ module.exports = {
         } else {
             // Target is AI, source is also AI. Check Target's opinion of Source.
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionValue = opinionEntry ? opinionEntry.opinon : 0;
+            opinionValue = opinionEntry ? opinionEntry.opinion : 0;
         }
 
         // Simplified check from original: only improve an already non-negative opinion.

--- a/default_userdata/scripts/actions/standard/newAllianceDiplomatic.js
+++ b/default_userdata/scripts/actions/standard/newAllianceDiplomatic.js
@@ -44,7 +44,7 @@ module.exports = {
             personal_diplo = target.getOpinionModifierValue("Personal Diplomacy");
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
             conversationOpinion = opinionOfSource > 0 ? opinionOfSource / 2 : 0; // Approximation
             if (target.faith === source.faith) {
                 religion_op = 10; // Approximation

--- a/default_userdata/scripts/actions/standard/offerVassalage.js
+++ b/default_userdata/scripts/actions/standard/offerVassalage.js
@@ -49,7 +49,7 @@ module.exports = {
             opinionOfSource = target.opinionOfPlayer;
         } else {
             const opinionEntry = target.opinions.find(o => o.id === source.id);
-            opinionOfSource = opinionEntry ? opinionEntry.opinon : 0;
+            opinionOfSource = opinionEntry ? opinionEntry.opinion : 0;
         }
 
         console.log(`PVAI: ${opinionOfSource} ${source.isLandedRuler} ${target.isLandedRuler}`)

--- a/default_userdata/scripts/gamedata_typedefs.js
+++ b/default_userdata/scripts/gamedata_typedefs.js
@@ -320,7 +320,7 @@ export class Character {
     relationsToPlayer: string[];
     relationsToCharacters: { id: number, relations: string[]}[];
     opinionBreakdownToPlayer: OpinionModifier[];
-    opinions: { id: number, opinon: number}[];
+    opinions: { id: number, opinion: number}[];
     relatives: Relative[];
     birthTotalDays?: number;
     // TODO: Use a proper Summary type once it's available in a shared location.

--- a/default_userdata/scripts/gamedata_typedefs.js
+++ b/default_userdata/scripts/gamedata_typedefs.js
@@ -37,6 +37,7 @@ export type Relative = {
     relationship: string; // 'Child', 'Spouse', 'Parent', 'Sibling', or game-engine relation strings
     sheHe?: string;
     birthDate?: string;
+    birthTotalDays?: number;
     isDeceased: boolean;
     deathDate?: string;
     deathReason?: string;
@@ -321,6 +322,7 @@ export class Character {
     opinionBreakdownToPlayer: OpinionModifier[];
     opinions: { id: number, opinon: number}[];
     relatives: Relative[];
+    birthTotalDays?: number;
     // TODO: Use a proper Summary type once it's available in a shared location.
     conversationSummaries: any[];
 
@@ -435,10 +437,11 @@ export class Character {
     }   
 
     /**
-     * Get a detailed formatted description of the character's relatives, including death/marital/trait info.
+     * Get a detailed formatted description of the character's relatives, including age, death/marital/trait info.
+     * @param gameTotalDays - current game date in total days (used to compute relative ages)
      * @returns {string} - Formatted relatives description or empty string if no relatives
      */
-    getRelativesDescription(): string {
+    getRelativesDescription(gameTotalDays: number): string {
         const structured = this.relatives.filter(r =>
             r.relationship === 'Parent' || r.relationship === 'Child' || r.relationship === 'Sibling'
         );
@@ -450,6 +453,15 @@ export class Character {
             byRelationship.get(rel.relationship)!.push(rel);
         }
 
+        const calcAge = (birthTotalDays: number): number =>
+            Math.floor((gameTotalDays - birthTotalDays) / 365.25);
+
+        const genderWord = (sheHe: string | undefined, word: string): string => {
+            if (sheHe === 'she') return word === 'sibling' ? 'sister' : word;
+            if (sheHe === 'he')  return word === 'sibling' ? 'brother' : word;
+            return word;
+        };
+
         const sectionOrder = ['Parent', 'Child', 'Sibling'];
         const sections: string[] = [];
 
@@ -459,8 +471,22 @@ export class Character {
 
             const label = relType === 'Child' ? 'Children' : relType === 'Parent' ? 'Parents' : 'Siblings';
             const memberStrs = members.map(rel => {
-                const parts: string[] = [rel.name];
+                const parts: string[] = [];
 
+                // Build the name prefix (e.g. "older brother Heardræd")
+                if (relType === 'Sibling' && rel.birthTotalDays !== undefined && this.birthTotalDays !== undefined) {
+                    const qualifier = rel.birthTotalDays < this.birthTotalDays ? 'older' : 'younger';
+                    parts.push(`${qualifier} ${genderWord(rel.sheHe, 'sibling')} ${rel.name}`);
+                } else {
+                    parts.push(rel.name);
+                }
+
+                // Age (living relatives only)
+                if (!rel.isDeceased && rel.birthTotalDays !== undefined) {
+                    parts.push(`age ${calcAge(rel.birthTotalDays)}`);
+                }
+
+                // Death / marital status
                 if (rel.isDeceased) {
                     parts.push(rel.deathDate ? `deceased ${rel.deathDate}` : 'deceased');
                 } else if (rel.maritalStatus === 'is_concubine' && rel.partners.length > 0) {
@@ -480,7 +506,8 @@ export class Character {
                     parts.push(`traits: ${rel.traits.map(t => t.name).join(', ')}`);
                 }
 
-                return parts.length > 1 ? `${parts[0]} (${parts.slice(1).join('; ')})` : parts[0];
+                const name = parts[0];
+                return parts.length > 1 ? `${name} (${parts.slice(1).join('; ')})` : name;
             });
 
             sections.push(`${label}: ${memberStrs.join(', ')}`);

--- a/default_userdata/scripts/gamedata_typedefs.js
+++ b/default_userdata/scripts/gamedata_typedefs.js
@@ -25,11 +25,26 @@ export type Secret = {
     category: string
 }
 
-export type FamilyMember = {
+export type RelativePartner = {
     id: number;
     name: string;
-    relationship: string; // 'Child', 'Spouse', 'Parent', 'Sibling'
-    characterId?: number;
+    type: 'spouse' | 'concubine' | 'betrothed';
+}
+
+export type Relative = {
+    id: number;
+    name: string;
+    relationship: string; // 'Child', 'Spouse', 'Parent', 'Sibling', or game-engine relation strings
+    sheHe?: string;
+    birthDate?: string;
+    isDeceased: boolean;
+    deathDate?: string;
+    deathReason?: string;
+    traits: { category: string; name: string; desc: string }[];
+    maritalStatus?: 'married' | 'is_concubine' | 'betrothed' | 'unmarried';
+    partners: RelativePartner[];
+    otherParentId?: number;
+    otherParentName?: string;
 }
 
 /** 
@@ -91,6 +106,58 @@ export class GameData {
     }
 
     /**
+     * Add a character to the characters map, ensuring player character is first
+     * @param id - Character ID
+     * @param character - Character object
+     */
+    addCharacter(id: number, character: Character): void {
+        console.log(`[GameData.addCharacter] Adding character ID: ${id}, name: ${character.fullName}`);
+        
+        // If this is the player character and map is not empty, reorder
+        if (id === this.playerID && this.characters.size > 0) {
+            console.log(`[GameData.addCharacter] This is player character, reordering map`);
+            const newMap = new Map<number, Character>();
+            newMap.set(id, character);
+            
+            // Add all existing characters
+            for (const [existingId, existingChar] of this.characters) {
+                newMap.set(existingId, existingChar);
+            }
+            
+            this.characters = newMap;
+            console.log(`[GameData.addCharacter] New character ID order: ${Array.from(this.characters.keys()).join(', ')}`);
+        } else {
+            this.characters.set(id, character);
+        }
+    }
+
+    /**
+     * Gets all character IDs with the player character first
+     * @returns {number[]} Array of character IDs with player ID first
+     */
+    getCharacterIdsWithPlayerFirst(): number[] {
+        const allIds = Array.from(this.characters.keys());
+        console.log(`[GameData.getCharacterIdsWithPlayerFirst] Raw character IDs: ${allIds.join(', ')}`);
+        console.log(`[GameData.getCharacterIdsWithPlayerFirst] Player ID: ${this.playerID}`);
+        
+        // Move player ID to the front if it exists
+        const playerIndex = allIds.indexOf(this.playerID);
+        console.log(`[GameData.getCharacterIdsWithPlayerFirst] Player index: ${playerIndex}`);
+        
+        if (playerIndex > 0) {
+            const playerId = allIds.splice(playerIndex, 1)[0];
+            allIds.unshift(playerId);
+            console.log(`[GameData.getCharacterIdsWithPlayerFirst] Moved player to front. New order: ${allIds.join(', ')}`);
+        } else if (playerIndex === 0) {
+            console.log(`[GameData.getCharacterIdsWithPlayerFirst] Player already at index 0`);
+        } else {
+            console.log(`[GameData.getCharacterIdsWithPlayerFirst] Player not found in character IDs`);
+        }
+        
+        return allIds;
+    }
+
+    /**
      * Gets all characters in the conversation except the player and the main AI.
      * @returns {Character[]} An array of other characters.
      */
@@ -100,15 +167,117 @@ export class GameData {
         );
     }
 
+    static fromPlainObject(obj: any): GameData {
+        // Create a dummy instance because constructor requires a string array
+        const instance = new GameData(new Array(9).fill(''));
+        Object.assign(instance, obj);
+
+        // Revive the characters Map from the plain object
+        const characterMap = new Map<number, Character>();
+        if (obj.characters) {
+            const playerId = instance.playerID;
+            let playerChar: Character | undefined;
+            
+            console.log(`[GameData.fromPlainObject] Player ID: ${playerId}`);
+            
+            // Check if obj.characters is a Map or a plain object
+            let entries: [any, any][];
+            if (obj.characters.entries && typeof obj.characters.entries === 'function') {
+                // It's a Map-like object
+                entries = Array.from(obj.characters.entries());
+            } else {
+                // It's a plain object
+                entries = Object.entries(obj.characters);
+            }
+            
+            console.log(`[GameData.fromPlainObject] Characters entries count: ${entries.length}`);
+            
+            for (const [id, charObj] of entries) {
+                const numericId = typeof id === 'string' ? parseInt(id, 10) : id;
+                const characterInstance = Character.fromPlainObject(charObj);
+                console.log(`[GameData.fromPlainObject] Processing character ID: ${numericId}, name: ${characterInstance.fullName}`);
+                if (numericId === playerId) {
+                    console.log(`[GameData.fromPlainObject] Found player character: ${characterInstance.fullName}`);
+                    playerChar = characterInstance;
+                } else {
+                    characterMap.set(numericId, characterInstance);
+                }
+            }
+            
+            // Add player character first if it was found
+            if (playerChar) {
+                const orderedMap = new Map<number, Character>();
+                orderedMap.set(playerId, playerChar);
+                console.log(`[GameData.fromPlainObject] Added player character ${playerChar.fullName} first to orderedMap`);
+                
+                // Add all other characters
+                for (const [id, char] of characterMap) {
+                    orderedMap.set(id, char);
+                    console.log(`[GameData.fromPlainObject] Added character ${char.fullName} (ID: ${id}) to orderedMap`);
+                }
+                
+                // Log the final order
+                const finalIds = Array.from(orderedMap.keys());
+                console.log(`[GameData.fromPlainObject] Final character ID order: ${finalIds.join(', ')}`);
+                console.log(`[GameData.fromPlainObject] Player ID ${playerId} is at index: ${finalIds.indexOf(playerId)}`);
+                
+                instance.characters = orderedMap;
+            } else {
+                console.log(`[GameData.fromPlainObject] Player character not found in characters map`);
+                instance.characters = characterMap;
+            }
+        } else {
+            console.log(`[GameData.fromPlainObject] No characters found in obj.characters`);
+        }
+        
+        // Ensure player is first
+        instance.ensurePlayerFirst();
+        
+        return instance;
+    }
+
     /**
      * Sets the names of non-player characters for use by parseVariables.
      * @deprecated This method is not scalable. Use getOtherCharacters() instead.
      */
     setCharacterNames(): void {
-        const nonPlayerCharacters = this.getOtherCharacters();
+        // const nonPlayerCharacters = this.getOtherCharacters();
         
-        this.character1Name = nonPlayerCharacters[0]?.shortName || "someone";
-        this.character2Name = nonPlayerCharacters[1]?.shortName || "another person";
+        // this.character1Name = nonPlayerCharacters[0]?.shortName || "someone";
+        // this.character2Name = nonPlayerCharacters[1]?.shortName || "another person";
+    }
+
+    /**
+     * Ensure the player character is first in the characters map
+     */
+    ensurePlayerFirst(): void {
+        const playerId = this.playerID;
+        const playerChar = this.characters.get(playerId);
+        
+        if (!playerChar) {
+            console.log(`[GameData.ensurePlayerFirst] Player character ${playerId} not found in map`);
+            return;
+        }
+        
+        const currentIds = Array.from(this.characters.keys());
+        if (currentIds.length > 0 && currentIds[0] !== playerId) {
+            console.log(`[GameData.ensurePlayerFirst] Player is not first. Current order: ${currentIds.join(', ')}`);
+            
+            const newMap = new Map<number, Character>();
+            newMap.set(playerId, playerChar);
+            
+            // Add all other characters
+            for (const [id, char] of this.characters) {
+                if (id !== playerId) {
+                    newMap.set(id, char);
+                }
+            }
+            
+            this.characters = newMap;
+            console.log(`[GameData.ensurePlayerFirst] New order: ${Array.from(this.characters.keys()).join(', ')}`);
+        } else {
+            console.log(`[GameData.ensurePlayerFirst] Player is already first or map is empty`);
+        }
     }
 }
 
@@ -151,7 +320,7 @@ export class Character {
     relationsToCharacters: { id: number, relations: string[]}[];
     opinionBreakdownToPlayer: OpinionModifier[];
     opinions: { id: number, opinon: number}[];
-    familyMembers: FamilyMember[];
+    relatives: Relative[];
     // TODO: Use a proper Summary type once it's available in a shared location.
     conversationSummaries: any[];
 
@@ -190,7 +359,7 @@ export class Character {
             this.relationsToCharacters = [],
             this.opinionBreakdownToPlayer = []
             this.opinions = [];
-            this.familyMembers = [];
+            this.relatives = [];
             this.conversationSummaries = [];
     }
 
@@ -266,32 +435,64 @@ export class Character {
     }   
 
     /**
-     * Get a formatted description of the character's family relationships
-     * @returns {string} - Formatted family description or empty string if no family
+     * Get a detailed formatted description of the character's relatives, including death/marital/trait info.
+     * @returns {string} - Formatted relatives description or empty string if no relatives
      */
-    getFamilyDescription(): string {
-        console.log(`Getting family description for ${this.fullName}, familyMembers count: ${this.familyMembers.length}`);
-        if (this.familyMembers.length === 0) {
-            console.log(`No family members for ${this.fullName}, returning empty string`);
-            return "";
+    getRelativesDescription(): string {
+        const structured = this.relatives.filter(r =>
+            r.relationship === 'Parent' || r.relationship === 'Child' || r.relationship === 'Sibling'
+        );
+        if (structured.length === 0) return "";
+
+        const byRelationship = new Map<string, Relative[]>();
+        for (const rel of structured) {
+            if (!byRelationship.has(rel.relationship)) byRelationship.set(rel.relationship, []);
+            byRelationship.get(rel.relationship)!.push(rel);
         }
-        
-        const byRelationship = new Map<string, string[]>();
-        this.familyMembers.forEach(member => {
-            if (!byRelationship.has(member.relationship)) {
-                byRelationship.set(member.relationship, []);
-            }
-            byRelationship.get(member.relationship)!.push(member.name);
-        });
-        
-        const parts: string[] = [];
-        byRelationship.forEach((names, relationship) => {
-            parts.push(`${relationship}: ${names.join(", ")}`);
-        });
-        
-        const result = `Family: ${parts.join(", ")}`;
-        console.log(`Family description for ${this.fullName}: ${result}`);
-        return result;
+
+        const sectionOrder = ['Parent', 'Child', 'Sibling'];
+        const sections: string[] = [];
+
+        for (const relType of sectionOrder) {
+            const members = byRelationship.get(relType);
+            if (!members || members.length === 0) continue;
+
+            const label = relType === 'Child' ? 'Children' : relType === 'Parent' ? 'Parents' : 'Siblings';
+            const memberStrs = members.map(rel => {
+                const parts: string[] = [rel.name];
+
+                if (rel.isDeceased) {
+                    parts.push(rel.deathDate ? `deceased ${rel.deathDate}` : 'deceased');
+                } else if (rel.maritalStatus === 'is_concubine' && rel.partners.length > 0) {
+                    parts.push(`concubine of ${rel.partners[0].name}`);
+                } else if (rel.maritalStatus === 'betrothed' && rel.partners.length > 0) {
+                    parts.push(`betrothed to ${rel.partners[0].name}`);
+                } else if (rel.maritalStatus === 'unmarried') {
+                    parts.push('unmarried');
+                } else if (rel.partners.length > 0) {
+                    const spouses = rel.partners.filter(p => p.type === 'spouse').map(p => p.name);
+                    const concubines = rel.partners.filter(p => p.type === 'concubine').map(p => p.name);
+                    if (spouses.length > 0) parts.push(`married to ${spouses.join(', ')}`);
+                    if (concubines.length > 0) parts.push(`concubine(s): ${concubines.join(', ')}`);
+                }
+
+                if (rel.traits && rel.traits.length > 0) {
+                    parts.push(`traits: ${rel.traits.map(t => t.name).join(', ')}`);
+                }
+
+                return parts.length > 1 ? `${parts[0]} (${parts.slice(1).join('; ')})` : parts[0];
+            });
+
+            sections.push(`${label}: ${memberStrs.join(', ')}`);
+        }
+
+        return sections.join('; ');
+    }
+
+    static fromPlainObject(obj: any): Character {
+        const instance = new Character(new Array(27).fill(''));
+        Object.assign(instance, obj);
+        return instance;
     }
 }
 

--- a/default_userdata/scripts/prompts/description/custom/pListMccZh_Custom.js
+++ b/default_userdata/scripts/prompts/description/custom/pListMccZh_Custom.js
@@ -254,7 +254,7 @@ module.exports = (gameData) =>{
     }
 
     function relatives(char){
-        return char.getRelativesDescription() || null;
+        return char.getRelativesDescription(gameData.totalDays) || null;
     }
 
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/custom/pListMccZh_Custom.js
+++ b/default_userdata/scripts/prompts/description/custom/pListMccZh_Custom.js
@@ -202,22 +202,22 @@ module.exports = (gameData) =>{
 
     function opinion(char){
         const op = char.opinionOfPlayer;
+        const sign = op >= 0 ? '+' : '';
+        let label;
+        if(op>60) label = `${char.shortName}对${player.shortName}有很大好感`;
+        else if(op>20) label = `${char.shortName}对${player.shortName}有轻微好感`;
+        else if(op>-20) label = `${char.shortName}对${player.shortName}态度中立`;
+        else if(op>-60) label = `${char.shortName}对${player.shortName}轻微厌恶`;
+        else label = `${char.shortName}对${player.shortName}强烈憎恨`;
 
-        if(op>60){
-            return `${char.shortName}对${player.shortName}有很大好感`
+        let result = `${label}（${sign}${op}）`;
+        if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+            const breakdown = char.opinionBreakdownToPlayer
+                .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+                .join('，');
+            result += `【原因：${breakdown}】`;
         }
-        else if(op>20){
-            return `${char.shortName}对${player.shortName}有轻微好感`
-        }
-        else if(op>-20){
-            return `${char.shortName}对${player.shortName}态度中立`
-        }
-        else if(op>-60){
-            return `${char.shortName}对${player.shortName}轻微厌恶`
-        }
-        else{
-             return `${char.shortName}对${player.shortName}强烈憎恨`
-        }
+        return result;
     }
 
     

--- a/default_userdata/scripts/prompts/description/custom/pListMccZh_Custom.js
+++ b/default_userdata/scripts/prompts/description/custom/pListMccZh_Custom.js
@@ -71,10 +71,11 @@ module.exports = (gameData) =>{
         personalityTraits(player), 
         otherTraits(player), 
         marriage(player),
+        relatives(player),
         describeProwess(player),
         goldStatus(player),
         age(player),
-        `信仰： ${player.faith}`, 
+        `信仰： ${player.faith}`,
         `民族： ${player.culture}`,
     ];
     
@@ -92,9 +93,10 @@ module.exports = (gameData) =>{
         greedines(ai),
         describeProwess(ai),
         marriage(ai),
+        relatives(ai),
         goldStatus(ai),
-        age(ai), 
-        `信仰： ${ai.faith}`, 
+        age(ai),
+        `信仰： ${ai.faith}`,
         `民族： ${ai.culture}`,
     ];
     
@@ -124,9 +126,10 @@ module.exports = (gameData) =>{
                     otherTraits(value), 
                     greedines(value), 
                     describeProwess(value),
-                    marriage(value),  
+                    marriage(value),
+                    relatives(value),
                     goldStatus(value),
-                    age(value), 
+                    age(value),
                     describeProwess(value),
                     `信仰：${value.faith}`, 
                     `民族：${value.culture}`]
@@ -249,7 +252,11 @@ module.exports = (gameData) =>{
             return ``;
         }
     }
-    
+
+    function relatives(char){
+        return char.getRelativesDescription() || null;
+    }
+
     function otherTraits(char){
         let otherTraits = char.traits.filter((trait) => trait.category != "性格特质");
     

--- a/default_userdata/scripts/prompts/description/standard/pList.js
+++ b/default_userdata/scripts/prompts/description/standard/pList.js
@@ -121,22 +121,22 @@ module.exports = (gameData) =>{
 
     function opinion(char){
         const op = char.opinionOfPlayer;
+        const sign = op >= 0 ? '+' : '';
+        let label;
+        if(op>60) label = `${char.shortName} has a very favorable opinion of ${player.shortName}`;
+        else if(op>20) label = `${char.shortName} has a slightly positive opinion of ${player.shortName}`;
+        else if(op>-20) label = `${char.shortName} has a neutral opinion of ${player.shortName}`;
+        else if(op>-60) label = `${char.shortName} has a slight hatred towards ${player.shortName}`;
+        else label = `${char.shortName} has a very strong hatred towards ${player.shortName}`;
 
-        if(op>60){
-            return `${char.shortName} has a very favorable opinion of ${player.shortName}`
+        let result = `${label} (${sign}${op})`;
+        if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+            const breakdown = char.opinionBreakdownToPlayer
+                .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+                .join(', ');
+            result += ` [reasons: ${breakdown}]`;
         }
-        else if(op>20){
-            return `${char.shortName} has a slightly positive opinion of ${player.shortName}`
-        }
-        else if(op>-20){
-            return `${char.shortName} has a neutral opinion of ${player.shortName}`
-        }
-        else if(op>-60){
-            return `${char.shortName} has a slight hatred towards ${player.shortName}`
-        }
-        else{
-             return `${char.shortName} has a very strong hatred towards ${player.shortName}`
-        }
+        return result;
     }
     
     

--- a/default_userdata/scripts/prompts/description/standard/pList.js
+++ b/default_userdata/scripts/prompts/description/standard/pList.js
@@ -173,7 +173,7 @@ module.exports = (gameData) =>{
     }
     
     function family(char){
-        return char.getRelativesDescription() || null;
+        return char.getRelativesDescription(gameData.totalDays) || null;
     }
     
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/standard/pList.js
+++ b/default_userdata/scripts/prompts/description/standard/pList.js
@@ -173,13 +173,7 @@ module.exports = (gameData) =>{
     }
     
     function family(char){
-        const familyDesc = char.getFamilyDescription();
-        if(familyDesc){
-            return familyDesc;
-        }
-        else{
-            return null;
-        }
+        return char.getRelativesDescription() || null;
     }
     
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/standard/pListLetter.js
+++ b/default_userdata/scripts/prompts/description/standard/pListLetter.js
@@ -174,22 +174,22 @@ module.exports = (gameData) =>{
 
     function opinion(char){
         const op = char.opinionOfPlayer;
+        const sign = op >= 0 ? '+' : '';
+        let label;
+        if(op>60) label = T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>20) label = T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>-20) label = T('opinion_neutral', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>-60) label = T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
+        else label = T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
 
-        if(op>60){
-            return T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: player.shortName});
+        let result = `${label} (${sign}${op})`;
+        if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+            const breakdown = char.opinionBreakdownToPlayer
+                .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+                .join(', ');
+            result += ` [reasons: ${breakdown}]`;
         }
-        else if(op>20){
-            return T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else if(op>-20){
-            return T('opinion_neutral', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else if(op>-60){
-            return T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else{
-             return T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
+        return result;
     }
 
     

--- a/default_userdata/scripts/prompts/description/standard/pListLetterZh.js
+++ b/default_userdata/scripts/prompts/description/standard/pListLetterZh.js
@@ -203,22 +203,22 @@ module.exports = (gameData) =>{
 
   function opinion(char){
     const op = char.opinionOfPlayer;
+    const sign = op >= 0 ? '+' : '';
+    let label;
+    if(op>60) label = `${char.shortName}对${player.shortName}有很大好感`;
+    else if(op>20) label = `${char.shortName}对${player.shortName}有轻微好感`;
+    else if(op>-20) label = `${char.shortName}对${player.shortName}态度中立`;
+    else if(op>-60) label = `${char.shortName}对${player.shortName}轻微厌恶`;
+    else label = `${char.shortName}对${player.shortName}强烈憎恨`;
 
-    if(op>60){
-      return `${char.shortName}对${player.shortName}有很大好感`
+    let result = `${label}（${sign}${op}）`;
+    if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+      const breakdown = char.opinionBreakdownToPlayer
+        .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+        .join('，');
+      result += `【原因：${breakdown}】`;
     }
-    else if(op>20){
-      return `${char.shortName}对${player.shortName}有轻微好感`
-    }
-    else if(op>-20){
-      return `${char.shortName}对${player.shortName}态度中立`
-    }
-    else if(op>-60){
-      return `${char.shortName}对${player.shortName}轻微厌恶`
-    }
-    else{
-      return `${char.shortName}对${player.shortName}强烈憎恨`
-    }
+    return result;
   }
 
 

--- a/default_userdata/scripts/prompts/description/standard/pListMcc.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc.js
@@ -261,7 +261,7 @@ module.exports = (gameData) =>{
     }
 
     function relatives(char){
-        return char.getRelativesDescription() || null;
+        return char.getRelativesDescription(gameData.totalDays) || null;
     }
     
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/standard/pListMcc.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc.js
@@ -209,22 +209,22 @@ module.exports = (gameData) =>{
 
     function opinion(char){
         const op = char.opinionOfPlayer;
+        const sign = op >= 0 ? '+' : '';
+        let label;
+        if(op>60) label = T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>20) label = T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>-20) label = T('opinion_neutral', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>-60) label = T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
+        else label = T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
 
-        if(op>60){
-            return T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: player.shortName});
+        let result = `${label} (${sign}${op})`;
+        if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+            const breakdown = char.opinionBreakdownToPlayer
+                .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+                .join(', ');
+            result += ` [reasons: ${breakdown}]`;
         }
-        else if(op>20){
-            return T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else if(op>-20){
-            return T('opinion_neutral', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else if(op>-60){
-            return T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else{
-             return T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
+        return result;
     }
     
     
@@ -325,17 +325,14 @@ module.exports = (gameData) =>{
                 const targetCharacter = gameData.characters.get(opinionData.id);
                 if (targetCharacter && targetCharacter.id !== char.id && targetCharacter.id !== player.id) {
                     const op = opinionData.opinion;
-                    if (op > 60) {
-                        return T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
-                    } else if (op > 20) {
-                        return T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
-                    } else if (op > -20) {
-                        return T('opinion_neutral', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
-                    } else if (op > -60) {
-                        return T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
-                    } else {
-                        return T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
-                    }
+                    const sign = op >= 0 ? '+' : '';
+                    let label;
+                    if (op > 60) label = T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
+                    else if (op > 20) label = T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
+                    else if (op > -20) label = T('opinion_neutral', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
+                    else if (op > -60) label = T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
+                    else label = T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: targetCharacter.shortName});
+                    return `${label} (${sign}${op})`;
                 }
                 return null;
             })

--- a/default_userdata/scripts/prompts/description/standard/pListMcc.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc.js
@@ -79,10 +79,11 @@ module.exports = (gameData) =>{
         personalityTraits(player), 
         otherTraits(player), 
         marriage(player),
+        relatives(player),
         describeProwess(player),
         goldStatus(player),
         age(player),
-        `${T('faith')}: ${player.faith}`, 
+        `${T('faith')}: ${player.faith}`,
         `${T('culture')}: ${player.culture}`,
     ];
     
@@ -101,9 +102,10 @@ module.exports = (gameData) =>{
         greedines(ai),
         describeProwess(ai),
         marriage(ai),
+        relatives(ai),
         goldStatus(ai),
-        age(ai), 
-        `${T('faith')}: ${ai.faith}`, 
+        age(ai),
+        `${T('faith')}: ${ai.faith}`,
         `${T('culture')}: ${ai.culture}`,
     ];
     
@@ -133,10 +135,11 @@ module.exports = (gameData) =>{
                 otherTraits(char), 
                 greedines(char), 
                 describeProwess(char),
-                marriage(char),  
+                marriage(char),
+                relatives(char),
                 goldStatus(char),
-                age(char), 
-                `${T('faith')}: ${char.faith}`, 
+                age(char),
+                `${T('faith')}: ${char.faith}`,
                 `${T('culture')}: ${char.culture}`]
             output+=`\n[${char.shortName}${T('s_persona')}: ${secondaryAiItems.join("; ")}]`;
         })
@@ -255,6 +258,10 @@ module.exports = (gameData) =>{
         else{
             return ``;
         }
+    }
+
+    function relatives(char){
+        return char.getRelativesDescription() || null;
     }
     
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/standard/pListMcc2.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc2.js
@@ -241,7 +241,7 @@ module.exports = (gameData) =>{
     }
 
     function relatives(char){
-        return char.getRelativesDescription() || null;
+        return char.getRelativesDescription(gameData.totalDays) || null;
     }
 
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/standard/pListMcc2.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc2.js
@@ -189,22 +189,22 @@ module.exports = (gameData) =>{
 
     function opinion(char){
         const op = char.opinionOfPlayer;
+        const sign = op >= 0 ? '+' : '';
+        let label;
+        if(op>60) label = T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>20) label = T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>-20) label = T('opinion_neutral', {charShortName: char.shortName, playerShortName: player.shortName});
+        else if(op>-60) label = T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
+        else label = T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
 
-        if(op>60){
-            return T('opinion_very_favorable', {charShortName: char.shortName, playerShortName: player.shortName});
+        let result = `${label} (${sign}${op})`;
+        if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+            const breakdown = char.opinionBreakdownToPlayer
+                .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+                .join(', ');
+            result += ` [reasons: ${breakdown}]`;
         }
-        else if(op>20){
-            return T('opinion_slightly_positive', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else if(op>-20){
-            return T('opinion_neutral', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else if(op>-60){
-            return T('opinion_slight_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
-        else{
-             return T('opinion_strong_hatred', {charShortName: char.shortName, playerShortName: player.shortName});
-        }
+        return result;
     }
 
     

--- a/default_userdata/scripts/prompts/description/standard/pListMcc2.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMcc2.js
@@ -58,10 +58,11 @@ module.exports = (gameData) =>{
         personalityTraits(player), 
         otherTraits(player), 
         marriage(player),
+        relatives(player),
         describeProwess(player),
         goldStatus(player),
         age(player),
-        `${T('faith')}: ${player.faith}`, 
+        `${T('faith')}: ${player.faith}`,
         `${T('culture')}: ${player.culture}`,
     ];
     
@@ -79,9 +80,10 @@ module.exports = (gameData) =>{
         greedines(ai),
         describeProwess(ai),
         marriage(ai),
+        relatives(ai),
         goldStatus(ai),
-        age(ai), 
-        `${T('faith')}: ${ai.faith}`, 
+        age(ai),
+        `${T('faith')}: ${ai.faith}`,
         `${T('culture')}: ${ai.culture}`,
     ];
     
@@ -111,11 +113,12 @@ module.exports = (gameData) =>{
                     otherTraits(value), 
                     greedines(value), 
                     describeProwess(value),
-                    marriage(value),  
+                    marriage(value),
+                    relatives(value),
                     goldStatus(value),
-                    age(value), 
+                    age(value),
                     describeProwess(value),
-                    `${T('faith')}: ${value.faith}`, 
+                    `${T('faith')}: ${value.faith}`,
                     `${T('culture')}: ${value.culture}`]
                 output+=`\n[${value.shortName}${T('s_persona')}: ${secondaryAiItems.join("; ")}]`;
             }
@@ -236,7 +239,11 @@ module.exports = (gameData) =>{
             return ``;
         }
     }
-    
+
+    function relatives(char){
+        return char.getRelativesDescription() || null;
+    }
+
     function otherTraits(char){
         let otherTraits = char.traits.filter((trait) => trait.category != T('personality_trait_category') && trait.category != "Personality Trait");
     

--- a/default_userdata/scripts/prompts/description/standard/pListMccZh.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMccZh.js
@@ -259,7 +259,7 @@ module.exports = (gameData) =>{
     }
 
     function relatives(char){
-        return char.getRelativesDescription() || null;
+        return char.getRelativesDescription(gameData.totalDays) || null;
     }
 
     function otherTraits(char){

--- a/default_userdata/scripts/prompts/description/standard/pListMccZh.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMccZh.js
@@ -207,22 +207,22 @@ module.exports = (gameData) =>{
 
     function opinion(char){
         const op = char.opinionOfPlayer;
+        const sign = op >= 0 ? '+' : '';
+        let label;
+        if(op>60) label = `${char.shortName}对${player.shortName}有很大好感`;
+        else if(op>20) label = `${char.shortName}对${player.shortName}有轻微好感`;
+        else if(op>-20) label = `${char.shortName}对${player.shortName}态度中立`;
+        else if(op>-60) label = `${char.shortName}对${player.shortName}轻微厌恶`;
+        else label = `${char.shortName}对${player.shortName}强烈憎恨`;
 
-        if(op>60){
-            return `${char.shortName}对${player.shortName}有很大好感`
+        let result = `${label}（${sign}${op}）`;
+        if(char.opinionBreakdownToPlayer && char.opinionBreakdownToPlayer.length > 0){
+            const breakdown = char.opinionBreakdownToPlayer
+                .map(m => `${m.reason}: ${m.value >= 0 ? '+' : ''}${m.value}`)
+                .join('，');
+            result += `【原因：${breakdown}】`;
         }
-        else if(op>20){
-            return `${char.shortName}对${player.shortName}有轻微好感`
-        }
-        else if(op>-20){
-            return `${char.shortName}对${player.shortName}态度中立`
-        }
-        else if(op>-60){
-            return `${char.shortName}对${player.shortName}轻微厌恶`
-        }
-        else{
-             return `${char.shortName}对${player.shortName}强烈憎恨`
-        }
+        return result;
     }
 
     

--- a/default_userdata/scripts/prompts/description/standard/pListMccZh.js
+++ b/default_userdata/scripts/prompts/description/standard/pListMccZh.js
@@ -76,10 +76,11 @@ module.exports = (gameData) =>{
         personalityTraits(player), 
         otherTraits(player), 
         marriage(player),
+        relatives(player),
         describeProwess(player),
         goldStatus(player),
         age(player),
-        `信仰： ${player.faith}`, 
+        `信仰： ${player.faith}`,
         `民族： ${player.culture}`,
     ];
     
@@ -97,9 +98,10 @@ module.exports = (gameData) =>{
         greedines(ai),
         describeProwess(ai),
         marriage(ai),
+        relatives(ai),
         goldStatus(ai),
-        age(ai), 
-        `信仰： ${ai.faith}`, 
+        age(ai),
+        `信仰： ${ai.faith}`,
         `民族： ${ai.culture}`,
     ];
     
@@ -129,9 +131,10 @@ module.exports = (gameData) =>{
                     otherTraits(value), 
                     greedines(value), 
                     describeProwess(value),
-                    marriage(value),  
+                    marriage(value),
+                    relatives(value),
                     goldStatus(value),
-                    age(value), 
+                    age(value),
                     describeProwess(value),
                     `信仰：${value.faith}`, 
                     `民族：${value.culture}`]
@@ -254,7 +257,11 @@ module.exports = (gameData) =>{
             return ``;
         }
     }
-    
+
+    function relatives(char){
+        return char.getRelativesDescription() || null;
+    }
+
     function otherTraits(char){
         let otherTraits = char.traits.filter((trait) => trait.category != "性格特质");
     

--- a/src/main/conversation/Conversation.ts
+++ b/src/main/conversation/Conversation.ts
@@ -811,8 +811,8 @@ export class Conversation{
             ].filter(Boolean).map(n => n.toLowerCase());
 
             const player = this.gameData.getPlayer();
-            if (player && player.familyMembers) {
-                const relationshipToPlayer = player.familyMembers.find(m => m.id === character.id);
+            if (player && player.relatives) {
+                const relationshipToPlayer = player.relatives.find(m => m.id === character.id);
                 if (relationshipToPlayer && relationshipToPlayer.relationship) {
                     checkables.push(relationshipToPlayer.relationship.toLowerCase());
                 }

--- a/src/shared/gameData/Character.ts
+++ b/src/shared/gameData/Character.ts
@@ -41,6 +41,7 @@ export class Character {
     opinionBreakdownToPlayer: OpinionModifier[];
     opinions: { id: number, opinon: number}[];
     relatives: Relative[];
+    birthTotalDays?: number;
     // TODO: Use a proper Summary type once it's available in a shared location.
     conversationSummaries: any[];
 
@@ -155,10 +156,11 @@ export class Character {
     }   
 
     /**
-     * Get a detailed formatted description of the character's relatives, including death/marital/trait info.
+     * Get a detailed formatted description of the character's relatives, including age, death/marital/trait info.
+     * @param gameTotalDays - current game date in total days (used to compute relative ages)
      * @returns {string} - Formatted relatives description or empty string if no relatives
      */
-    getRelativesDescription(): string {
+    getRelativesDescription(gameTotalDays: number): string {
         const structured = this.relatives.filter(r =>
             r.relationship === 'Parent' || r.relationship === 'Child' || r.relationship === 'Sibling'
         );
@@ -170,6 +172,15 @@ export class Character {
             byRelationship.get(rel.relationship)!.push(rel);
         }
 
+        const calcAge = (birthTotalDays: number): number =>
+            Math.floor((gameTotalDays - birthTotalDays) / 365.25);
+
+        const genderWord = (sheHe: string | undefined, word: string): string => {
+            if (sheHe === 'she') return word === 'sibling' ? 'sister' : word;
+            if (sheHe === 'he')  return word === 'sibling' ? 'brother' : word;
+            return word;
+        };
+
         const sectionOrder = ['Parent', 'Child', 'Sibling'];
         const sections: string[] = [];
 
@@ -179,8 +190,22 @@ export class Character {
 
             const label = relType === 'Child' ? 'Children' : relType === 'Parent' ? 'Parents' : 'Siblings';
             const memberStrs = members.map(rel => {
-                const parts: string[] = [rel.name];
+                const parts: string[] = [];
 
+                // Build the name prefix (e.g. "older brother Heardræd")
+                if (relType === 'Sibling' && rel.birthTotalDays !== undefined && this.birthTotalDays !== undefined) {
+                    const qualifier = rel.birthTotalDays < this.birthTotalDays ? 'older' : 'younger';
+                    parts.push(`${qualifier} ${genderWord(rel.sheHe, 'sibling')} ${rel.name}`);
+                } else {
+                    parts.push(rel.name);
+                }
+
+                // Age (living relatives only)
+                if (!rel.isDeceased && rel.birthTotalDays !== undefined) {
+                    parts.push(`age ${calcAge(rel.birthTotalDays)}`);
+                }
+
+                // Death / marital status
                 if (rel.isDeceased) {
                     parts.push(rel.deathDate ? `deceased ${rel.deathDate}` : 'deceased');
                 } else if (rel.maritalStatus === 'is_concubine' && rel.partners.length > 0) {
@@ -200,7 +225,8 @@ export class Character {
                     parts.push(`traits: ${rel.traits.map(t => t.name).join(', ')}`);
                 }
 
-                return parts.length > 1 ? `${parts[0]} (${parts.slice(1).join('; ')})` : parts[0];
+                const name = parts[0];
+                return parts.length > 1 ? `${name} (${parts.slice(1).join('; ')})` : name;
             });
 
             sections.push(`${label}: ${memberStrs.join(', ')}`);

--- a/src/shared/gameData/Character.ts
+++ b/src/shared/gameData/Character.ts
@@ -39,7 +39,7 @@ export class Character {
     relationsToPlayer: string[];
     relationsToCharacters: { id: number, relations: string[]}[];
     opinionBreakdownToPlayer: OpinionModifier[];
-    opinions: { id: number, opinon: number}[];
+    opinions: { id: number, opinion: number}[];
     relatives: Relative[];
     birthTotalDays?: number;
     // TODO: Use a proper Summary type once it's available in a shared location.

--- a/src/shared/gameData/Character.ts
+++ b/src/shared/gameData/Character.ts
@@ -1,4 +1,4 @@
-import {Memory, Trait, OpinionModifier, Secret, FamilyMember} from "./GameData"
+import {Memory, Trait, OpinionModifier, Secret, Relative} from "./GameData"
 import { removeTooltip } from "./parseLog";
 
 /** @class */
@@ -40,7 +40,7 @@ export class Character {
     relationsToCharacters: { id: number, relations: string[]}[];
     opinionBreakdownToPlayer: OpinionModifier[];
     opinions: { id: number, opinon: number}[];
-    familyMembers: FamilyMember[];
+    relatives: Relative[];
     // TODO: Use a proper Summary type once it's available in a shared location.
     conversationSummaries: any[];
 
@@ -79,7 +79,7 @@ export class Character {
             this.relationsToCharacters = [],
             this.opinionBreakdownToPlayer = []
             this.opinions = [];
-            this.familyMembers = [];
+            this.relatives = [];
             this.conversationSummaries = [];
     }
 
@@ -155,32 +155,58 @@ export class Character {
     }   
 
     /**
-     * Get a formatted description of the character's family relationships
-     * @returns {string} - Formatted family description or empty string if no family
+     * Get a detailed formatted description of the character's relatives, including death/marital/trait info.
+     * @returns {string} - Formatted relatives description or empty string if no relatives
      */
-    getFamilyDescription(): string {
-        console.log(`Getting family description for ${this.fullName}, familyMembers count: ${this.familyMembers.length}`);
-        if (this.familyMembers.length === 0) {
-            console.log(`No family members for ${this.fullName}, returning empty string`);
-            return "";
+    getRelativesDescription(): string {
+        const structured = this.relatives.filter(r =>
+            r.relationship === 'Parent' || r.relationship === 'Child' || r.relationship === 'Sibling'
+        );
+        if (structured.length === 0) return "";
+
+        const byRelationship = new Map<string, Relative[]>();
+        for (const rel of structured) {
+            if (!byRelationship.has(rel.relationship)) byRelationship.set(rel.relationship, []);
+            byRelationship.get(rel.relationship)!.push(rel);
         }
-        
-        const byRelationship = new Map<string, string[]>();
-        this.familyMembers.forEach(member => {
-            if (!byRelationship.has(member.relationship)) {
-                byRelationship.set(member.relationship, []);
-            }
-            byRelationship.get(member.relationship)!.push(member.name);
-        });
-        
-        const parts: string[] = [];
-        byRelationship.forEach((names, relationship) => {
-            parts.push(`${relationship}: ${names.join(", ")}`);
-        });
-        
-        const result = `Family: ${parts.join(", ")}`;
-        console.log(`Family description for ${this.fullName}: ${result}`);
-        return result;
+
+        const sectionOrder = ['Parent', 'Child', 'Sibling'];
+        const sections: string[] = [];
+
+        for (const relType of sectionOrder) {
+            const members = byRelationship.get(relType);
+            if (!members || members.length === 0) continue;
+
+            const label = relType === 'Child' ? 'Children' : relType === 'Parent' ? 'Parents' : 'Siblings';
+            const memberStrs = members.map(rel => {
+                const parts: string[] = [rel.name];
+
+                if (rel.isDeceased) {
+                    parts.push(rel.deathDate ? `deceased ${rel.deathDate}` : 'deceased');
+                } else if (rel.maritalStatus === 'is_concubine' && rel.partners.length > 0) {
+                    parts.push(`concubine of ${rel.partners[0].name}`);
+                } else if (rel.maritalStatus === 'betrothed' && rel.partners.length > 0) {
+                    parts.push(`betrothed to ${rel.partners[0].name}`);
+                } else if (rel.maritalStatus === 'unmarried') {
+                    parts.push('unmarried');
+                } else if (rel.partners.length > 0) {
+                    const spouses = rel.partners.filter(p => p.type === 'spouse').map(p => p.name);
+                    const concubines = rel.partners.filter(p => p.type === 'concubine').map(p => p.name);
+                    if (spouses.length > 0) parts.push(`married to ${spouses.join(', ')}`);
+                    if (concubines.length > 0) parts.push(`concubine(s): ${concubines.join(', ')}`);
+                }
+
+                if (rel.traits && rel.traits.length > 0) {
+                    parts.push(`traits: ${rel.traits.map(t => t.name).join(', ')}`);
+                }
+
+                return parts.length > 1 ? `${parts[0]} (${parts.slice(1).join('; ')})` : parts[0];
+            });
+
+            sections.push(`${label}: ${memberStrs.join(', ')}`);
+        }
+
+        return sections.join('; ');
     }
 
     static fromPlainObject(obj: any): Character {

--- a/src/shared/gameData/GameData.ts
+++ b/src/shared/gameData/GameData.ts
@@ -40,6 +40,7 @@ export type Relative = {
     relationship: string; // 'Child', 'Spouse', 'Parent', 'Sibling', or game-engine relation strings
     sheHe?: string;
     birthDate?: string;
+    birthTotalDays?: number;
     isDeceased: boolean;
     deathDate?: string;
     deathReason?: string;

--- a/src/shared/gameData/GameData.ts
+++ b/src/shared/gameData/GameData.ts
@@ -28,11 +28,26 @@ export type Secret = {
     category: string
 }
 
-export type FamilyMember = {
+export type RelativePartner = {
     id: number;
     name: string;
-    relationship: string; // 'Child', 'Spouse', 'Parent', 'Sibling'
-    characterId?: number;
+    type: 'spouse' | 'concubine' | 'betrothed';
+}
+
+export type Relative = {
+    id: number;
+    name: string;
+    relationship: string; // 'Child', 'Spouse', 'Parent', 'Sibling', or game-engine relation strings
+    sheHe?: string;
+    birthDate?: string;
+    isDeceased: boolean;
+    deathDate?: string;
+    deathReason?: string;
+    traits: { category: string; name: string; desc: string }[];
+    maritalStatus?: 'married' | 'is_concubine' | 'betrothed' | 'unmarried';
+    partners: RelativePartner[];
+    otherParentId?: number;
+    otherParentName?: string;
 }
 
 /** 

--- a/src/shared/gameData/parseLog.ts
+++ b/src/shared/gameData/parseLog.ts
@@ -58,6 +58,8 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
     let isWaitingForMultiLine: boolean = false;
     let multiLineType: string = ""; //relation or opinionModifier
 
+    const deferredRelations: { charAID: number, charBID: number, relationship: string }[] = [];
+
     // Efficiently find the last block by reading from the end of the file
     const relevantLogBlock = await readLastRelevantBlock(debugLogPath);
 
@@ -224,6 +226,18 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
             }
         }
     }
+
+    for (const entry of deferredRelations) {
+        const charA = gameData?.characters.get(entry.charAID);
+        const charB = gameData?.characters.get(entry.charBID);
+        if (!charA || !charB) {
+            if (!charA) console.warn(`Character with ID ${entry.charAID} not found after full parse (new_relations)`);
+            if (!charB) console.warn(`Character with ID ${entry.charBID} not found after full parse (new_relations)`);
+            continue;
+        }
+        commitNewRelation(entry.charAID, entry.charBID, entry.relationship);
+    }
+
     console.debug("Finished parsing log file. Game data loaded from last block.");
 
     function commitNewRelation(charAID: number, charBID: number, relationship: string): void {
@@ -231,8 +245,7 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
         const charA = gameData.characters.get(charAID);
         const charB = gameData.characters.get(charBID);
         if (!charA || !charB) {
-            if (!charA) console.warn(`Character with ID ${charAID} not found when parsing family data`);
-            if (!charB) console.warn(`Character with ID ${charBID} not found when parsing family data`);
+            deferredRelations.push({ charAID, charBID, relationship });
             return;
         }
         if (!charA.familyMembers.some(m => m.id === charBID && m.relationship === relationship)) {

--- a/src/shared/gameData/parseLog.ts
+++ b/src/shared/gameData/parseLog.ts
@@ -1,4 +1,4 @@
-import { GameData, Memory, Trait, OpinionModifier, Secret} from "./GameData";
+import { GameData, Memory, Trait, OpinionModifier, Secret, Relative} from "./GameData";
 import { Character } from "./Character";
 const fs = require('fs');
 
@@ -219,6 +219,130 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
                         console.debug(`Starting multi-line parse for "opinionBreakdown" for character ID ${rootID}.`);
                     }
                     break;
+
+                // --- log_relatives: parents ---
+                case "parents":
+                    if (!gameData) continue;
+                    upsertRelative(rootID, Number(data[1]), data[2], 'Parent', { birthDate: data[4] });
+                    break;
+                case "parent_death": {
+                    if (!gameData) continue;
+                    const pd = findRelative(rootID, Number(data[1]));
+                    if (pd) { pd.isDeceased = true; pd.deathDate = data[3]; pd.deathReason = data[4]; }
+                    break;
+                }
+
+                // --- log_relatives: kids ---
+                case "kids":
+                    if (!gameData) continue;
+                    upsertRelative(rootID, Number(data[1]), data[2], 'Child', { sheHe: data[3], birthDate: data[5] });
+                    break;
+                case "kid_other_parent": {
+                    if (!gameData) continue;
+                    const kop = findRelative(rootID, Number(data[1]));
+                    if (kop) { kop.otherParentId = Number(data[2]); kop.otherParentName = data[3]; }
+                    break;
+                }
+                case "kid_death": {
+                    if (!gameData) continue;
+                    const kd = findRelative(rootID, Number(data[1]));
+                    if (kd) { kd.isDeceased = true; kd.deathDate = data[3]; kd.deathReason = data[4]; }
+                    break;
+                }
+                case "kid_trait": {
+                    if (!gameData) continue;
+                    const kt = findRelative(rootID, Number(data[1]));
+                    if (kt) kt.traits.push({ category: data[2], name: data[3], desc: data[4] });
+                    break;
+                }
+                case "kid_is_concubine": {
+                    if (!gameData) continue;
+                    const kic = findRelative(rootID, Number(data[1]));
+                    if (kic) { kic.maritalStatus = 'is_concubine'; kic.partners.push({ id: Number(data[2]), name: data[3], type: 'spouse' }); }
+                    break;
+                }
+                case "kid_concubine": {
+                    if (!gameData) continue;
+                    const kcon = findRelative(rootID, Number(data[1]));
+                    if (kcon) { kcon.maritalStatus = 'married'; kcon.partners.push({ id: Number(data[2]), name: data[3], type: 'concubine' }); }
+                    break;
+                }
+                case "kid_spouse": {
+                    if (!gameData) continue;
+                    const ks = findRelative(rootID, Number(data[1]));
+                    if (ks) { ks.maritalStatus = 'married'; ks.partners.push({ id: Number(data[2]), name: data[3], type: 'spouse' }); }
+                    break;
+                }
+                case "kid_betrothed": {
+                    if (!gameData) continue;
+                    const kb = findRelative(rootID, Number(data[1]));
+                    if (kb) { kb.maritalStatus = 'betrothed'; kb.partners.push({ id: Number(data[2]), name: data[3], type: 'betrothed' }); }
+                    break;
+                }
+                case "kid_unmarried": {
+                    if (!gameData) continue;
+                    const ku = findRelative(rootID, Number(data[1]));
+                    if (ku) ku.maritalStatus = 'unmarried';
+                    break;
+                }
+                case "kid_eob":
+                    break;
+
+                // --- log_relatives: siblings ---
+                case "siblings":
+                    if (!gameData) continue;
+                    upsertRelative(rootID, Number(data[1]), data[2], 'Sibling', { sheHe: data[3], birthDate: data[5] });
+                    break;
+                case "sibling_other_parent": {
+                    if (!gameData) continue;
+                    const sop = findRelative(rootID, Number(data[1]));
+                    if (sop) { sop.otherParentId = Number(data[2]); sop.otherParentName = data[3]; }
+                    break;
+                }
+                case "sibling_death": {
+                    if (!gameData) continue;
+                    const sd = findRelative(rootID, Number(data[1]));
+                    if (sd) { sd.isDeceased = true; sd.deathDate = data[3]; sd.deathReason = data[4]; }
+                    break;
+                }
+                case "sibling_trait": {
+                    if (!gameData) continue;
+                    const st = findRelative(rootID, Number(data[1]));
+                    if (st) st.traits.push({ category: data[2], name: data[3], desc: data[4] });
+                    break;
+                }
+                case "sibling_is_concubine": {
+                    if (!gameData) continue;
+                    const sic = findRelative(rootID, Number(data[1]));
+                    if (sic) { sic.maritalStatus = 'is_concubine'; sic.partners.push({ id: Number(data[2]), name: data[3], type: 'spouse' }); }
+                    break;
+                }
+                case "sibling_concubine": {
+                    if (!gameData) continue;
+                    const scon = findRelative(rootID, Number(data[1]));
+                    if (scon) { scon.maritalStatus = 'married'; scon.partners.push({ id: Number(data[2]), name: data[3], type: 'concubine' }); }
+                    break;
+                }
+                case "sibling_spouse": {
+                    if (!gameData) continue;
+                    const ss = findRelative(rootID, Number(data[1]));
+                    if (ss) { ss.maritalStatus = 'married'; ss.partners.push({ id: Number(data[2]), name: data[3], type: 'spouse' }); }
+                    break;
+                }
+                case "sibling_betrothed": {
+                    if (!gameData) continue;
+                    const sbet = findRelative(rootID, Number(data[1]));
+                    if (sbet) { sbet.maritalStatus = 'betrothed'; sbet.partners.push({ id: Number(data[2]), name: data[3], type: 'betrothed' }); }
+                    break;
+                }
+                case "sibling_unmarried": {
+                    if (!gameData) continue;
+                    const su = findRelative(rootID, Number(data[1]));
+                    if (su) su.maritalStatus = 'unmarried';
+                    break;
+                }
+                case "sibling_eob":
+                    break;
             }
         } else {
             if (line.trim() !== "") {
@@ -240,6 +364,25 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
 
     console.debug("Finished parsing log file. Game data loaded from last block.");
 
+    function findRelative(rootID: number, relativeID: number): Relative | undefined {
+        return gameData?.characters.get(rootID)?.relatives.find(r => r.id === relativeID);
+    }
+
+    function upsertRelative(rootID: number, id: number, name: string, relationship: string, extras?: Partial<Relative>): void {
+        if (!gameData) return;
+        const char = gameData.characters.get(rootID);
+        if (!char) return;
+        let rel = char.relatives.find(r => r.id === id);
+        if (!rel) {
+            rel = { id, name, relationship, isDeceased: false, traits: [], partners: [] };
+            char.relatives.push(rel);
+        } else {
+            if (name) rel.name = name;
+            if (relationship) rel.relationship = relationship;
+        }
+        if (extras) Object.assign(rel, extras);
+    }
+
     function commitNewRelation(charAID: number, charBID: number, relationship: string): void {
         if (!gameData || !relationship) return;
         const charA = gameData.characters.get(charAID);
@@ -248,8 +391,8 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
             deferredRelations.push({ charAID, charBID, relationship });
             return;
         }
-        if (!charA.familyMembers.some(m => m.id === charBID && m.relationship === relationship)) {
-            charA.familyMembers.push({ id: charBID, name: charB.fullName, relationship });
+        if (!charA.relatives.some(m => m.id === charBID)) {
+            charA.relatives.push({ id: charBID, name: charB.fullName, relationship, isDeceased: false, traits: [], partners: [] });
             console.log(`Parsed family for character ${charAID} (${charA.fullName}): ${relationship} ${charB.fullName} (ID: ${charBID})`);
         }
         if (charAID === gameData.playerID) {

--- a/src/shared/gameData/parseLog.ts
+++ b/src/shared/gameData/parseLog.ts
@@ -80,15 +80,20 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
             console.log(`Parsing multi-line data of type "${multiLineType}": ${line}`);
             let value = line.split('#')[0]
             switch (multiLineType){
-                case "new_relations":
-                    value = removeTooltip(value)
-                    // if (value.includes("your")) {
-
-                    //     value = value.replace("your", gameData.playerName+"'s");
-                    // }
-                    multiLineTempStorage.push(value)
-                    console.log(`Parsed multi-line new_relation: "${value}"`);
-                break;
+                case "new_relations": {
+                    const pending = multiLineTempStorage[0] as { charAID: number, charBID: number, relationship: string };
+                    // Accumulate any relationship text that fell on a continuation line
+                    const addition = removeTooltip(value);
+                    if (addition) {
+                        pending.relationship = pending.relationship
+                            ? pending.relationship + ' ' + addition
+                            : addition;
+                    }
+                    // Commit once the full relationship text is known
+                    if (line.includes('#ENDMULTILINE')) {
+                        commitNewRelation(pending.charAID, pending.charBID, pending.relationship);
+                    }
+                break; }
                 case "relations":
                     const relation = removeTooltip(value);
                     multiLineTempStorage.push(relation);
@@ -186,32 +191,17 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
                     if (!gameData) continue;
                     const characterA_ID = rootID;
                     const characterB_ID = Number(data[1]);
-                    
-                    let relationship = "";
-                    const parts = line.split('#');
-                    if (parts.length > 1) {
-                        relationship = removeTooltip(parts[1]);
-                    }
 
-                    if (relationship) {
-                        const characterA = gameData.characters.get(characterA_ID);
-                        const characterB = gameData.characters.get(characterB_ID);
+                    const initialRelationship = line.includes('#')
+                        ? removeTooltip(line.split('#')[1])
+                        : "";
 
-                        if (characterA && characterB) {
-                            // Avoid adding duplicates
-                            const exists = characterA.familyMembers.some(member => member.id === characterB_ID && member.relationship === relationship);
-                            if (!exists) {
-                                characterA.familyMembers.push({
-                                    id: characterB_ID,
-                                    name: characterB.fullName,
-                                    relationship: relationship
-                                });
-                                console.log(`Parsed family for character ${characterA_ID} (${characterA.fullName}): ${relationship} ${characterB.fullName} (ID: ${characterB_ID})`);
-                            }
-                        } else {
-                            if (!characterA) console.warn(`Character with ID ${characterA_ID} not found when parsing family data`);
-                            if (!characterB) console.warn(`Character with ID ${characterB_ID} not found when parsing family data`);
-                        }
+                    if (line.includes('#ENDMULTILINE')) {
+                        commitNewRelation(characterA_ID, characterB_ID, initialRelationship);
+                    } else {
+                        multiLineTempStorage = [{ charAID: characterA_ID, charBID: characterB_ID, relationship: initialRelationship }];
+                        isWaitingForMultiLine = true;
+                        multiLineType = "new_relations";
                     }
                     break;
 
@@ -235,6 +225,32 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
         }
     }
     console.debug("Finished parsing log file. Game data loaded from last block.");
+
+    function commitNewRelation(charAID: number, charBID: number, relationship: string): void {
+        if (!gameData || !relationship) return;
+        const charA = gameData.characters.get(charAID);
+        const charB = gameData.characters.get(charBID);
+        if (!charA || !charB) {
+            if (!charA) console.warn(`Character with ID ${charAID} not found when parsing family data`);
+            if (!charB) console.warn(`Character with ID ${charBID} not found when parsing family data`);
+            return;
+        }
+        if (!charA.familyMembers.some(m => m.id === charBID && m.relationship === relationship)) {
+            charA.familyMembers.push({ id: charBID, name: charB.fullName, relationship });
+            console.log(`Parsed family for character ${charAID} (${charA.fullName}): ${relationship} ${charB.fullName} (ID: ${charBID})`);
+        }
+        if (charAID === gameData.playerID) {
+            if (!charB.relationsToPlayer.includes(relationship)) {
+                charB.relationsToPlayer.push(relationship);
+                console.log(`Parsed relationsToPlayer for character ${charBID} (${charB.fullName}): "${relationship}"`);
+            }
+        } else if (charBID === gameData.playerID) {
+            if (!charA.relationsToPlayer.includes(relationship)) {
+                charA.relationsToPlayer.push(relationship);
+                console.log(`Parsed relationsToPlayer for character ${charAID} (${charA.fullName}): "${relationship}"`);
+            }
+        }
+    }
 
     function parseMemory(data: string[]): Memory{
         return {

--- a/src/shared/gameData/parseLog.ts
+++ b/src/shared/gameData/parseLog.ts
@@ -223,7 +223,7 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
                 // --- log_relatives: parents ---
                 case "parents":
                     if (!gameData) continue;
-                    upsertRelative(rootID, Number(data[1]), data[2], 'Parent', { birthDate: data[4] });
+                    upsertRelative(rootID, Number(data[1]), data[2], 'Parent', { birthDate: data[4], birthTotalDays: Number(data[3]) });
                     break;
                 case "parent_death": {
                     if (!gameData) continue;
@@ -235,7 +235,7 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
                 // --- log_relatives: kids ---
                 case "kids":
                     if (!gameData) continue;
-                    upsertRelative(rootID, Number(data[1]), data[2], 'Child', { sheHe: data[3], birthDate: data[5] });
+                    upsertRelative(rootID, Number(data[1]), data[2], 'Child', { sheHe: data[3], birthDate: data[5], birthTotalDays: Number(data[4]) });
                     break;
                 case "kid_other_parent": {
                     if (!gameData) continue;
@@ -291,7 +291,7 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
                 // --- log_relatives: siblings ---
                 case "siblings":
                     if (!gameData) continue;
-                    upsertRelative(rootID, Number(data[1]), data[2], 'Sibling', { sheHe: data[3], birthDate: data[5] });
+                    upsertRelative(rootID, Number(data[1]), data[2], 'Sibling', { sheHe: data[3], birthDate: data[5], birthTotalDays: Number(data[4]) });
                     break;
                 case "sibling_other_parent": {
                     if (!gameData) continue;
@@ -362,6 +362,20 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
         commitNewRelation(entry.charAID, entry.charBID, entry.relationship);
     }
 
+    // Propagate birthTotalDays to Character objects that were added after the relative log was parsed
+    if (gameData) {
+        for (const char of gameData.characters.values()) {
+            for (const rel of char.relatives) {
+                if (rel.birthTotalDays !== undefined) {
+                    const relChar = gameData.characters.get(rel.id);
+                    if (relChar && relChar.birthTotalDays === undefined) {
+                        relChar.birthTotalDays = rel.birthTotalDays;
+                    }
+                }
+            }
+        }
+    }
+
     console.debug("Finished parsing log file. Game data loaded from last block.");
 
     function findRelative(rootID: number, relativeID: number): Relative | undefined {
@@ -381,6 +395,13 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
             if (relationship) rel.relationship = relationship;
         }
         if (extras) Object.assign(rel, extras);
+        // Propagate birthTotalDays to the Character object itself if it exists in the map
+        if (extras?.birthTotalDays !== undefined) {
+            const relativeChar = gameData.characters.get(id);
+            if (relativeChar && relativeChar.birthTotalDays === undefined) {
+                relativeChar.birthTotalDays = extras.birthTotalDays;
+            }
+        }
     }
 
     function commitNewRelation(charAID: number, charBID: number, relationship: string): void {

--- a/src/shared/gameData/parseLog.ts
+++ b/src/shared/gameData/parseLog.ts
@@ -171,7 +171,7 @@ async function readLastRelevantBlock(filePath: string): Promise<string | undefin
                 break;
                 case "opinions":
                     if (!gameData) continue;
-                    gameData!.characters.get(rootID)!.opinions.push({id: Number(data[1]), opinon: Number(data[2])});
+                    gameData!.characters.get(rootID)!.opinions.push({id: Number(data[1]), opinion: Number(data[2])});
                     console.log(`Parsed opinion for character ID ${rootID}: targetID=${data[1]}, value=${data[2]}`);
                 break;
                 case "relations":


### PR DESCRIPTION
This is a big one, sorry, most of the changes come in from the e0b0127 so it's worth looking at the earlier commits and taking those at least...

The key changes (which are separable if need be) in order of commit:
327fae8 + 24372d2 -- these fix the existing parsing being a bit borked, leading to missing relationships
c1f1730 + d75f841 -- these add all relatives to the context, not just player-character relationships
e0b0127 -- improving opinion context and fixing typos

Motivation:
- I found that relatives of characters were being captured very inconsistently, it was possible to have a conversation with your own mother and have her unaware you were related, very sad.
- I also found that there was actually loads of info on relatives being logged by the mod but never read by the application.
- I wasn't convinced opinions were being used correctly in all cases

The end result of this PR is that characters now know their relation to the player more reliably, but also have context for all their own relatives (who may or may not be in the same conversation). Also the age so it can infer about seniority. Also, opinions should more reliably be used to inform conversations, with the reasons passed rather than just a vague "slightly positive".

Here's an example of the improved context passed to the LLM, note "older sister", "younger brother" etc.


```txt
[Master Ronwald's Persona: Leader of Scholars of Abbastun, a group of Scholars; nobleman of house Kellingas; personality(Temperate, Patient, Lazy, Content); traits(Insightful Thinker, Modest, Peasant Leader, Zeitgeist: Fire and Blood, Quick); unmarried; Parents: Ceolweard (age 49), Sægyth (age 43); Siblings: older sister Eoforhild Sægythsdohtor (age 25; unmarried; traits: Ambitious, Forgiving, Patient, Mastermind Philosopher, Modest, Novice Physician, Delicate, Traveler), older brother Heardræd Sægythson (age 27; unmarried; traits: Vengeful, Diligent, Trusting, Fortune Builder, Herbalist, Modest, Hale, Fecund, Traveler), younger brother Æscmann Sægythson (age 2; unmarried; traits: Modest); age(21); faith(Catholicism); culture(West Saxon); wealth(282 gold)]
```

Obvs this has the opportunity to bloat context significantly, and perhaps should be gated behind a flag in future (or at least the traits which may be overkill). As far as I can tell the mod only logs immediate family, but I haven't tested that extensively.

And an example of better relationship context:

```txt
[Ceolweard's Persona: A follower of Master Ronwald Ceolweardson of Scholars of Abbastun, they are a group of Scholars; Bodyguard of Master Ronwald Ceolweardson of Scholars of Abbastun; Ceolweard is the Father Bodyguard  \x16bodyguard_court_position_icon Knight, Son Liege of Master Ronwald; lowborn man; Ceolweard has a very favorable opinion of Master Ronwald (+100) [reasons: Child: +50, Hygiene Disciplinarian: +10, Detailed Maps: +10, \x16prestige_level_2_icon V Distinguished: +3, Personal Diplomacy: +11, Temperate: +10, Also Temperate: +10, Bodyguard: +5, Friendly: +14, Life of the Party: +19, Difficulty: -10, Kind Ruler: +5, Modest: -10, Peasant Leader: -10]; ...
```

Along the way, Claude also claimed it had fixed a bug with a typo `opinon` rather than `opinion` leading that field to be undefined in some places and interpreted as strong hatred, but I can't confirm that.

## Detailed Changes


### fix: relationships to player not being captured properly (`parseLog.ts`)
The `new_relations` log entry uses a multi-line format but the parser was treating it as single-line, discarding any relationship text that spanned a continuation line. Refactored into a two-phase approach: accumulate text across continuation lines into a pending struct, then call `commitNewRelation()` at `#ENDMULTILINE`. Extracted `commitNewRelation()` helper which also correctly populates `relationsToPlayer` on both characters when either side is the player — this was previously missing entirely.

### fix: handle deferred relationships during log parsing (`parseLog.ts`)
When `commitNewRelation()` was called before both characters had been parsed (possible depending on log order), it would drop the relationship. Added a `deferredRelations` array; entries that can't be resolved immediately are pushed there and committed in a second pass after the full log block is consumed.

### feat: capture all immediate family as context (`GameData.ts`, `Character.ts`, `parseLog.ts`, `gamedata_typedefs.js`, `pList*.js`)
Replaced the shallow `FamilyMember` type (id/name/relationship only) with a richer `Relative` type capturing gender (`sheHe`), birth date, death date/reason, marital status, partners, traits, and other-parent info. Added parsers for all `log_relatives` log entries (`parents`, `kids`, `siblings` and their sub-entries: death, traits, spouse/concubine/betrothed, etc.). Renamed `familyMembers` → `relatives` throughout and replaced `getFamilyDescription()` with `getRelativesDescription()`, which renders structured sections (Parents / Children / Siblings) with marital and death detail per entry.

### feat: enhance relative descriptions with age and birth details (`Character.ts`, `parseLog.ts`)
Extended `Relative` with `birthTotalDays` and `Character` with `birthTotalDays`. `getRelativesDescription()` now takes the current game date to compute ages and labels siblings as "older/brother", "younger/sister" etc. based on birth order. `birthTotalDays` is propagated from relative log entries back onto the `Character` map so siblings share the same data regardless of whose log entry it appeared in first.

### refactor: opinion handling in character descriptions (`pList*.js`, `gamedata_typedefs.js`, `Character.ts`, `parseLog.ts`)
Opinion output in character descriptions now includes the numeric value and a breakdown of reasons. Before, only a prose label was returned (e.g. "has a slightly positive opinion"). After: `"has a slightly positive opinion (+34) [reasons: Friend: +25, Same culture: +10, ...]"`. Also fixes a longstanding typo: `opinon` → `opinion` in the `Character` class and all downstream JS typedef copies, with a corresponding fix in the `parseLog.ts` push call.
