### PR TITLE
Add Grant Independence action and fix independence war invalidation

### DIFF
--- a/default_userdata/scripts/actions/standard/declareWar.js
+++ b/default_userdata/scripts/actions/standard/declareWar.js
@@ -1,5 +1,6 @@
-/** @import { GameData, Character } from '../../gamedata_typedefs.js' */
+//Made by: unknown,adjusted by patrick
 
+/** @import { GameData, Character } from '../../gamedata_typedefs.js' */
 function sanitizeScriptKey(input) {
   return String(input || "").replace(/[^a-zA-Z0-9_]/g, "");
 }
@@ -146,10 +147,14 @@ module.exports = {
     const manualTargetTitle = sanitizeScriptKey(rawTargetTitle);
     const inferredTargetTitle = inferTargetTitleKey(targetCharacter);
     const isClaimLikeCb = casusBelli.includes("claim");
+    
+    // Some CBs (like independence or liberty) do not take a target_title at all and will invalidate if one is provided.
+    const noTargetCbList = ["independence_war", "independence_faction_war", "liberty_war", "liberty_faction_war"];
+    const isNoTargetCb = noTargetCbList.includes(casusBelli);
 
     const autoPickClaimTarget = isClaimLikeCb && !manualTargetTitle;
     const targetTitle = autoPickClaimTarget ? "" : (manualTargetTitle || inferredTargetTitle);
-    const hasTargetTitle = !!targetTitle;
+    const hasTargetTitle = !!targetTitle && !isNoTargetCb;
 
     const titleLine = hasTargetTitle ? `\n        target_title = title:${targetTitle}` : "";
     const claimantLine = isClaimLikeCb ? "\n        claimant = global_var:votcce_action_source" : "";

--- a/default_userdata/scripts/actions/standard/grantIndependence.js
+++ b/default_userdata/scripts/actions/standard/grantIndependence.js
@@ -30,7 +30,7 @@ module.exports = {
 
         // Action is only available if there is a direct liege-vassal relationship
         const isLiegeVassal = source.liege === target.fullName || source.liege === target.shortName || 
-                              target.liege === source.fullName || target.liege === target.shortName;
+                              target.liege === source.fullName || target.liege === source.shortName;
                               
         return !!isLiegeVassal;
     },
@@ -54,7 +54,7 @@ module.exports = {
         }
 
         const isLiegeVassal = source.liege === target.fullName || source.liege === target.shortName || 
-                              target.liege === source.fullName || target.liege === target.shortName;
+                              target.liege === source.fullName || target.liege === source.shortName;
 
         if (!isLiegeVassal) {
             return { success: false, message: "Granting independence requires a liege-vassal relationship between the two characters." };
@@ -82,7 +82,7 @@ module.exports = {
         if (source.liege === target.fullName || source.liege === target.shortName) {
             vassalGlobalVar = "global_var:votcce_action_source";
             vassal = source;
-        } else if (target.liege === source.fullName || target.liege === target.shortName) {
+        } else if (target.liege === source.fullName || target.liege === source.shortName) {
             vassalGlobalVar = "global_var:votcce_action_target";
             vassal = target;
         }

--- a/default_userdata/scripts/actions/standard/grantIndependence.js
+++ b/default_userdata/scripts/actions/standard/grantIndependence.js
@@ -1,0 +1,127 @@
+//Made by: a dude(patrick)
+
+/** @import { GameData, Character } from '../../gamedata_typedefs.js' */
+module.exports = {
+    signature: "grantIndependence",
+    isDestructive: true,
+    args: [],
+    description: {
+        en: "Grants independence to a vassal (removes their liege). Use this to peacefully grant independence or accept a demand for independence. If a demand for independence is rejected, do NOT use this action; instead, the vassal should use the declareWar action with the independence_war casus_belli.",
+        zh: "æŽˆäºˆé™„åº¸ç‹¬ç«‹ï¼ˆç§»é™¤å…¶é¢†ä¸»ï¼‰ã€‚ç”¨äºŽå’Œå¹³æŽˆäºˆç‹¬ç«‹æˆ–æŽ¥å—ç‹¬ç«‹è¦æ±‚ã€‚å¦‚æžœæ‹’ç»ç‹¬ç«‹è¦æ±‚ï¼Œè¯·ä¸è¦ä½¿ç”¨æ­¤æ“ä½œï¼›è€Œåº”ç”±é™„åº¸ä½¿ç”¨å¸¦æœ‰ independence_war æˆ˜äº‰å€Ÿå£çš„ declareWar æ“ä½œã€‚",
+        ru: "ÐŸÑ€ÐµÐ´Ð¾ÑÑ‚Ð°Ð²Ð»ÑÐµÑ‚ Ð½ÐµÐ·Ð°Ð²Ð¸ÑÐ¸Ð¼Ð¾ÑÑ‚ÑŒ Ð²Ð°ÑÑÐ°Ð»Ñƒ (ÑƒÐ´Ð°Ð»ÑÐµÑ‚ ÐµÐ³Ð¾ ÑŽÐ·ÐµÑ€ÐµÐ½Ð°). Ð˜ÑÐ¿Ð¾Ð»ÑŒÐ·ÑƒÐ¹Ñ‚Ðµ Ð´Ð»Ñ Ð¼Ð¸Ñ€Ð½Ð¾Ð³Ð¾ Ð¿Ñ€ÐµÐ´Ð¾ÑÑ‚Ð°Ð²Ð»ÐµÐ½Ð¸Ñ Ð½ÐµÐ·Ð°Ð²Ð¸ÑÐ¸Ð¼Ð¾ÑÑ‚Ð¸ Ð¸Ð»Ð¸ Ð¿Ñ€Ð¸Ð½ÑÑ‚Ð¸Ñ Ñ‚Ñ€ÐµÐ±Ð¾Ð²Ð°Ð½Ð¸Ñ. Ð•ÑÐ»Ð¸ Ñ‚Ñ€ÐµÐ±Ð¾Ð²Ð°Ð½Ð¸Ðµ Ð¾Ñ‚ÐºÐ»Ð¾Ð½ÐµÐ½Ð¾, ÐÐ• Ð¸ÑÐ¿Ð¾Ð»ÑŒÐ·ÑƒÐ¹Ñ‚Ðµ ÑÑ‚Ð¾ Ð´ÐµÐ¹ÑÑ‚Ð²Ð¸Ðµ; Ð²Ð¼ÐµÑÑ‚Ð¾ ÑÑ‚Ð¾Ð³Ð¾ Ð²Ð°ÑÑÐ°Ð» Ð´Ð¾Ð»Ð¶ÐµÐ½ Ð¸ÑÐ¿Ð¾Ð»ÑŒÐ·Ð¾Ð²Ð°Ñ‚ÑŒ declareWar Ñ casus_belli independence_war.",
+        fr: "Accorde l'indÃ©pendance Ã  un vassal (retire son lige). Utilisez-le pour accorder pacifiquement l'indÃ©pendance ou accepter une demande d'indÃ©pendance. Si la demande est rejetÃ©e, utilisez plutÃ´t declareWar avec le casus_belli independence_war.",
+        es: "Otorga la independencia a un vasallo (elimina a su seÃ±or). Ãšselo para conceder la independencia pacÃficamente o aceptar una demanda de independencia. Si se rechaza, use declareWar con el casus_belli independence_war.",
+        de: "GewÃ¤hrt einem Vasallen die UnabhÃ¤ngigkeit (entfernt seinen Lehnsherrn). Verwenden Sie dies fÃ¼r eine friedliche Trennung oder um einer Forderung zuzustimmen. Wenn abgelehnt, verwenden Sie stattdessen declareWar mit independence_war.",
+        ja: "å®¶è‡£ã«ç‹¬ç«‹ã‚’ä¸Žãˆã¾ã™ï¼ˆä¸»å›ã‚’å¤–ã—ã¾ã™ï¼‰ã€‚å¹³å’Œè£ã«ç‹¬ç«‹ã‚’èªã‚ã‚‹ã‹ã€è¦æ±‚ã‚’å—ã‘å…¥ã‚Œã‚‹å ´åˆã«ä½¿ç”¨ã—ã¾ã™ã€‚æ‹’å¦ã™ã‚‹å ´åˆã¯ã€ä»£ã‚ã‚Šã« independence_war ã‚’ä½¿ã£ã¦ declareWar ã‚’å®Ÿè¡Œã—ã¦ãã ã•ã„ã€‚",
+        ko: "ë´‰ì‹ ì—ê²Œ ë…ë¦½ì„ ë¶€ì—¬í•©ë‹ˆë‹¤(êµ°ì£¼ë¥¼ ì œê±°í•©ë‹ˆë‹¤). í‰í™”ë¡­ê²Œ ë…ë¦½ì„ ë¶€ì—¬í•˜ê±°ë‚˜ ë…ë¦½ ìš”êµ¬ë¥¼ ìˆ˜ë½í•  ë•Œ ì‚¬ìš©í•˜ì‹ì‹œì˜¤. ê±°ì ˆí•  ê²½ìš° independence_warì™€ í•¨ê»˜ declareWarë¥¼ ì‚¬ìš©í•˜ì‹ì‹œì˜¤.",
+        pl: "Nadaje niepodlegÅ‚oÅ›Ä‡ wasalowi (usuwa jego seniora). UÅ¼yj tego, aby pokojowo przyznaÄ‡ niepodlegÅ‚oÅ›Ä‡ lub zaakceptowaÄ‡ Å¼Ä…danie. W przypadku odmowy uÅ¼yj declareWar z casus_belli independence_war.",
+        pt: "Concede a independÃªncia a um vassalo (remove seu suserano). Use isso para conceder a independÃªncia pacificamente ou aceitar uma exigÃªncia de independÃªncia. Se for rejeitada, use declareWar com o casus_belli independence_war."
+    },
+ 
+    /**
+     * @param {GameData} gameData
+     * @param {number} sourceId
+     * @param {number} targetId
+     */
+    check: (gameData, sourceId, targetId) => {
+        const source = gameData.getCharacterById(sourceId);
+        const target = gameData.getCharacterById(targetId);
+        if (!source || !target || sourceId === targetId) return false;
+
+        // Action is only available if there is a direct liege-vassal relationship
+        const isLiegeVassal = source.liege === target.fullName || source.liege === target.shortName || 
+                              target.liege === source.fullName || target.liege === target.shortName;
+                              
+        return !!isLiegeVassal;
+    },
+
+    /**
+     * @param {GameData} gameData
+     * @param {string[]} args
+     * @param {number} sourceId
+     * @param {number} targetId
+     * @returns {{success: boolean, message?: string}}
+     */
+    preCheck: (gameData, args, sourceId, targetId) => {
+        const source = gameData.getCharacterById(sourceId);
+        const target = gameData.getCharacterById(targetId);
+        if (!source || !target) {
+            return { success: false, message: "Source or target character not found." };
+        }
+        
+        if (sourceId === targetId) {
+            return { success: false, message: "Source and target must be different characters." };
+        }
+
+        const isLiegeVassal = source.liege === target.fullName || source.liege === target.shortName || 
+                              target.liege === source.fullName || target.liege === target.shortName;
+
+        if (!isLiegeVassal) {
+            return { success: false, message: "Granting independence requires a liege-vassal relationship between the two characters." };
+        }
+
+        return { success: true };
+    },
+
+    /**
+     * @param {GameData} gameData
+     * @param {function} runGameEffect
+     * @param {string[]} args
+     * @param {number} sourceId
+     * @param {number} targetId
+     */
+    run: (gameData, runGameEffect, args, sourceId, targetId) => {
+        const source = gameData.getCharacterById(sourceId);
+        const target = gameData.getCharacterById(targetId);
+        if (!source || !target) return;
+
+        let vassalGlobalVar = "";
+        let vassal = null;
+
+        // Determine who the vassal is
+        if (source.liege === target.fullName || source.liege === target.shortName) {
+            vassalGlobalVar = "global_var:votcce_action_source";
+            vassal = source;
+        } else if (target.liege === source.fullName || target.liege === target.shortName) {
+            vassalGlobalVar = "global_var:votcce_action_target";
+            vassal = target;
+        }
+        
+        if (!vassal) return;
+
+        runGameEffect(`
+            create_title_and_vassal_change = {
+                type = independency
+                save_scope_as = change
+                add_claim_on_loss = no
+            }
+            ${vassalGlobalVar} = {
+                becomes_independent = {
+                    change = scope:change
+                }
+            }
+            resolve_title_and_vassal_change = scope:change
+        `);
+
+        console.log(`[grantIndependence] Vassal '${vassal.shortName}' has been granted independence.`);
+        // Update local state to reflect the severed tie
+        vassal.liege = "";
+    },
+
+    chatMessage: (args) => {
+        return {
+            en: `The liege-vassal relationship between {{character1Name}} and {{character2Name}} has been dissolved.`,  
+            zh: `{{character1Name}} å’Œ {{character2Name}} ä¹‹é—´çš„é¢†ä¸»-é™„åº¸å…³ç³»å·²ç»è§£é™¤ã€‚`,  
+            ru: `ÐžÑ‚Ð½Ð¾ÑˆÐµÐ½Ð¸Ñ ÑŽÐ·ÐµÑ€ÐµÐ½Ð°-Ð²Ð°ÑÑÐ°Ð»Ð° Ð¼ÐµÐ¶Ð´Ñƒ {{character1Name}} Ð¸ {{character2Name}} Ð±Ñ‹Ð»Ð¸ Ñ€Ð°ÑÑ‚Ð¾Ñ€Ð³Ð½ÑƒÑ‚Ñ‹.`,
+            fr: `La relation suzerain-vassal entre {{character1Name}} et {{character2Name}} a Ã©tÃ© dissoute.`,
+            es: `La relaciÃ³n seÃ±or-vasallo entre {{character1Name}} y {{character2Name}} se ha disuelto.`,  
+            de: `Die Lehnsherr-Vasall-Beziehung zwischen {{character1Name}} und {{character2Name}} wurde aufgelÃ¶st.`,
+            ja: `{{character1Name}} ã¨ {{character2Name}} ã®é–“ã®ä¸»å›ãƒ»å®¶è‡£é–“ã®é–¢ä¿‚ãŒè§£æ¶ˆã•ã‚Œã¾ã—ãŸã€‚`,
+            ko: `{{character1Name}}ì™€ {{character2Name}} ì‚¬ì´ì˜ êµ°ì£¼-ë´‰ì‹  ê´€ê³„ê°€ í•´ì†Œë˜ì—ˆìŠµë‹ˆë‹¤.`,
+            pl: `Relacja senior-wasal miÄ™dzy {{character1Name}} a {{character2Name}} zostaÅ‚a rozwiÄ…zana.`,
+            pt: `A relaÃ§Ã£o suserano-vassalo entre {{character1Name}} e {{character2Name}} foi dissolvida.`  
+        };
+    },
+
+    chatMessageClass: "neutral-action-message"
+};

--- a/default_userdata/scripts/actions/standard/grantIndependence.js
+++ b/default_userdata/scripts/actions/standard/grantIndependence.js
@@ -7,15 +7,15 @@ module.exports = {
     args: [],
     description: {
         en: "Grants independence to a vassal (removes their liege). Use this to peacefully grant independence or accept a demand for independence. If a demand for independence is rejected, do NOT use this action; instead, the vassal should use the declareWar action with the independence_war casus_belli.",
-        zh: "æŽˆäºˆé™„åº¸ç‹¬ç«‹ï¼ˆç§»é™¤å…¶é¢†ä¸»ï¼‰ã€‚ç”¨äºŽå’Œå¹³æŽˆäºˆç‹¬ç«‹æˆ–æŽ¥å—ç‹¬ç«‹è¦æ±‚ã€‚å¦‚æžœæ‹’ç»ç‹¬ç«‹è¦æ±‚ï¼Œè¯·ä¸è¦ä½¿ç”¨æ­¤æ“ä½œï¼›è€Œåº”ç”±é™„åº¸ä½¿ç”¨å¸¦æœ‰ independence_war æˆ˜äº‰å€Ÿå£çš„ declareWar æ“ä½œã€‚",
-        ru: "ÐŸÑ€ÐµÐ´Ð¾ÑÑ‚Ð°Ð²Ð»ÑÐµÑ‚ Ð½ÐµÐ·Ð°Ð²Ð¸ÑÐ¸Ð¼Ð¾ÑÑ‚ÑŒ Ð²Ð°ÑÑÐ°Ð»Ñƒ (ÑƒÐ´Ð°Ð»ÑÐµÑ‚ ÐµÐ³Ð¾ ÑŽÐ·ÐµÑ€ÐµÐ½Ð°). Ð˜ÑÐ¿Ð¾Ð»ÑŒÐ·ÑƒÐ¹Ñ‚Ðµ Ð´Ð»Ñ Ð¼Ð¸Ñ€Ð½Ð¾Ð³Ð¾ Ð¿Ñ€ÐµÐ´Ð¾ÑÑ‚Ð°Ð²Ð»ÐµÐ½Ð¸Ñ Ð½ÐµÐ·Ð°Ð²Ð¸ÑÐ¸Ð¼Ð¾ÑÑ‚Ð¸ Ð¸Ð»Ð¸ Ð¿Ñ€Ð¸Ð½ÑÑ‚Ð¸Ñ Ñ‚Ñ€ÐµÐ±Ð¾Ð²Ð°Ð½Ð¸Ñ. Ð•ÑÐ»Ð¸ Ñ‚Ñ€ÐµÐ±Ð¾Ð²Ð°Ð½Ð¸Ðµ Ð¾Ñ‚ÐºÐ»Ð¾Ð½ÐµÐ½Ð¾, ÐÐ• Ð¸ÑÐ¿Ð¾Ð»ÑŒÐ·ÑƒÐ¹Ñ‚Ðµ ÑÑ‚Ð¾ Ð´ÐµÐ¹ÑÑ‚Ð²Ð¸Ðµ; Ð²Ð¼ÐµÑÑ‚Ð¾ ÑÑ‚Ð¾Ð³Ð¾ Ð²Ð°ÑÑÐ°Ð» Ð´Ð¾Ð»Ð¶ÐµÐ½ Ð¸ÑÐ¿Ð¾Ð»ÑŒÐ·Ð¾Ð²Ð°Ñ‚ÑŒ declareWar Ñ casus_belli independence_war.",
-        fr: "Accorde l'indÃ©pendance Ã  un vassal (retire son lige). Utilisez-le pour accorder pacifiquement l'indÃ©pendance ou accepter une demande d'indÃ©pendance. Si la demande est rejetÃ©e, utilisez plutÃ´t declareWar avec le casus_belli independence_war.",
-        es: "Otorga la independencia a un vasallo (elimina a su seÃ±or). Ãšselo para conceder la independencia pacÃficamente o aceptar una demanda de independencia. Si se rechaza, use declareWar con el casus_belli independence_war.",
-        de: "GewÃ¤hrt einem Vasallen die UnabhÃ¤ngigkeit (entfernt seinen Lehnsherrn). Verwenden Sie dies fÃ¼r eine friedliche Trennung oder um einer Forderung zuzustimmen. Wenn abgelehnt, verwenden Sie stattdessen declareWar mit independence_war.",
-        ja: "å®¶è‡£ã«ç‹¬ç«‹ã‚’ä¸Žãˆã¾ã™ï¼ˆä¸»å›ã‚’å¤–ã—ã¾ã™ï¼‰ã€‚å¹³å’Œè£ã«ç‹¬ç«‹ã‚’èªã‚ã‚‹ã‹ã€è¦æ±‚ã‚’å—ã‘å…¥ã‚Œã‚‹å ´åˆã«ä½¿ç”¨ã—ã¾ã™ã€‚æ‹’å¦ã™ã‚‹å ´åˆã¯ã€ä»£ã‚ã‚Šã« independence_war ã‚’ä½¿ã£ã¦ declareWar ã‚’å®Ÿè¡Œã—ã¦ãã ã•ã„ã€‚",
-        ko: "ë´‰ì‹ ì—ê²Œ ë…ë¦½ì„ ë¶€ì—¬í•©ë‹ˆë‹¤(êµ°ì£¼ë¥¼ ì œê±°í•©ë‹ˆë‹¤). í‰í™”ë¡­ê²Œ ë…ë¦½ì„ ë¶€ì—¬í•˜ê±°ë‚˜ ë…ë¦½ ìš”êµ¬ë¥¼ ìˆ˜ë½í•  ë•Œ ì‚¬ìš©í•˜ì‹ì‹œì˜¤. ê±°ì ˆí•  ê²½ìš° independence_warì™€ í•¨ê»˜ declareWarë¥¼ ì‚¬ìš©í•˜ì‹ì‹œì˜¤.",
-        pl: "Nadaje niepodlegÅ‚oÅ›Ä‡ wasalowi (usuwa jego seniora). UÅ¼yj tego, aby pokojowo przyznaÄ‡ niepodlegÅ‚oÅ›Ä‡ lub zaakceptowaÄ‡ Å¼Ä…danie. W przypadku odmowy uÅ¼yj declareWar z casus_belli independence_war.",
-        pt: "Concede a independÃªncia a um vassalo (remove seu suserano). Use isso para conceder a independÃªncia pacificamente ou aceitar uma exigÃªncia de independÃªncia. Se for rejeitada, use declareWar com o casus_belli independence_war."
+        zh: "授予附庸独立（移除其领主）。用于和平授予独立或接受独立要求。如果独立要求被拒绝，请不要使用此操作；而应由附庸使用带有 independence_war 战争借口的 declareWar 操作。",
+        ru: "Предоставляет независимость вассалу (удаляет его сюзерена). Используйте для мирного предоставления независимости или принятия требования. Если требование отклонено, НЕ используйте это действие; вместо этого вассал должен использовать declareWar с casus_belli independence_war.",
+        fr: "Accorde l'indépendance à un vassal (retire son liege). Utilisez-le pour accorder pacifiquement l'indépendance ou accepter une demande d'indépendance. Si la demande est rejetée, utilisez plutôt declareWar avec le casus_belli independence_war.",
+        es: "Otorga la independencia a un vasallo (elimina a su señor). Úselo para conceder la independencia pacíficamente o aceptar una demanda de independencia. Si se rechaza, use declareWar con el casus_belli independence_war.",
+        de: "Gewährt einem Vasallen die Unabhängigkeit (entfernt seinen Lehnsherrn). Verwenden Sie dies für eine friedliche Trennung oder um einer Forderung zuzustimmen. Wenn abgelehnt, verwenden Sie stattdessen declareWar mit independence_war.",
+        ja: "家臣に独立を与えます（主君を外します）。平和裏に独立を認めるか、要求を受け入れる場合に使用します。拒否する場合は、代わりに independence_war を使って declareWar を実行してください。",
+        ko: "봉신에게 독립을 부여합니다(군주를 제거합니다). 평화롭게 독립을 부여하거나 독립 요구를 수락할 때 사용하십시오. 거절할 경우 independence_war와 함께 declareWar를 사용하십시오.",
+        pl: "Nadaje niepodległość wasalowi (usuwa jego seniora). Użyj tego, aby pokojowo przyznać niepodległość lub zaakceptować żądanie. W przypadku odmowy użyj declareWar z casus_belli independence_war.",
+        pt: "Concede a independência a um vassalo (remove seu suserano). Use isso para conceder a independência pacificamente ou aceitar uma exigência de independência. Se for rejeitada, use declareWar com o casus_belli independence_war."
     },
  
     /**
@@ -111,15 +111,15 @@ module.exports = {
     chatMessage: (args) => {
         return {
             en: `The liege-vassal relationship between {{character1Name}} and {{character2Name}} has been dissolved.`,  
-            zh: `{{character1Name}} å’Œ {{character2Name}} ä¹‹é—´çš„é¢†ä¸»-é™„åº¸å…³ç³»å·²ç»è§£é™¤ã€‚`,  
-            ru: `ÐžÑ‚Ð½Ð¾ÑˆÐµÐ½Ð¸Ñ ÑŽÐ·ÐµÑ€ÐµÐ½Ð°-Ð²Ð°ÑÑÐ°Ð»Ð° Ð¼ÐµÐ¶Ð´Ñƒ {{character1Name}} Ð¸ {{character2Name}} Ð±Ñ‹Ð»Ð¸ Ñ€Ð°ÑÑ‚Ð¾Ñ€Ð³Ð½ÑƒÑ‚Ñ‹.`,
-            fr: `La relation suzerain-vassal entre {{character1Name}} et {{character2Name}} a Ã©tÃ© dissoute.`,
-            es: `La relaciÃ³n seÃ±or-vasallo entre {{character1Name}} y {{character2Name}} se ha disuelto.`,  
-            de: `Die Lehnsherr-Vasall-Beziehung zwischen {{character1Name}} und {{character2Name}} wurde aufgelÃ¶st.`,
-            ja: `{{character1Name}} ã¨ {{character2Name}} ã®é–“ã®ä¸»å›ãƒ»å®¶è‡£é–“ã®é–¢ä¿‚ãŒè§£æ¶ˆã•ã‚Œã¾ã—ãŸã€‚`,
-            ko: `{{character1Name}}ì™€ {{character2Name}} ì‚¬ì´ì˜ êµ°ì£¼-ë´‰ì‹  ê´€ê³„ê°€ í•´ì†Œë˜ì—ˆìŠµë‹ˆë‹¤.`,
-            pl: `Relacja senior-wasal miÄ™dzy {{character1Name}} a {{character2Name}} zostaÅ‚a rozwiÄ…zana.`,
-            pt: `A relaÃ§Ã£o suserano-vassalo entre {{character1Name}} e {{character2Name}} foi dissolvida.`  
+            zh: `{{character1Name}} 和 {{character2Name}} 之间的领主-附庸关系已被解除。`,  
+            ru: `Отношения юзерена-вассала между {{character1Name}} и {{character2Name}} были расторгнуты.`,
+            fr: `La relation suzerain-vassal entre {{character1Name}} et {{character2Name}} a été dissoute.`,
+            es: `La relación señor-vasallo entre {{character1Name}} y {{character2Name}} se ha disuelto.`,  
+            de: `Die Lehnsherr-Vasall-Beziehung zwischen {{character1Name}} und {{character2Name}} wurde aufgelöst.`,
+            ja: `{{character1Name}} と {{character2Name}} の間の主君・家臣関係が解消されました。`,
+            ko: `{{character1Name}}과 {{character2Name}} 사이의 군주-봉신 관계가 해소되었습니다.`,
+            pl: `Relacja senior-wasal między {{character1Name}} a {{character2Name}} została rozwiązana.`,
+            pt: `A relação suserano-vassalo entre {{character1Name}} e {{character2Name}} foi dissolvida.` 
         };
     },
 


### PR DESCRIPTION
**Changes:**
* Added the `grantIndependence` standard action. It supports both a liege granting independence and a liege accepting a vassal's demand for it.
* Patched `declareWar.js` to omit the `target_title` parameter for specific casus bellis (independence and liberty wars). This resolves the issue where wars triggered through chat were instantly invalidated by the game engine when unpaused.